### PR TITLE
[Small bug fix] benchmark stats by language - pull the correct pass rate for each language

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -548,9 +548,9 @@ def summarize_results(dirname, verbose, stats_languages=None):
         lang_stats.avg_duration_per_test = 0
         lang_stats.cost = 0
         for i in range(tries):
-            setattr(lang_stats, f"pass_rate_{i+1}", 0)
+            setattr(lang_stats, f"pass_rate_{i + 1}", 0)
         for i in range(tries):
-            setattr(lang_stats, f"pass_num_{i+1}", 0)
+            setattr(lang_stats, f"pass_num_{i + 1}", 0)
         lang_stats.error_outputs = 0
         lang_stats.user_asks = 0
         lang_stats.test_timeouts = 0
@@ -636,7 +636,7 @@ def summarize_results(dirname, verbose, stats_languages=None):
     for i in range(tries):
         pass_rate = 100 * passed_tests[i] / res.completed_tests
         percents[i] = pass_rate
-        # console.print(f"{pass_rate:.1f}% correct after try {i+1}")
+        # console.print(f"{pass_rate:.1f}% correct after try {i + 1}")
         setattr(res, f"pass_rate_{i + 1}", f"{pass_rate:.1f}")
         setattr(res, f"pass_num_{i + 1}", passed_tests[i])
 
@@ -704,6 +704,7 @@ def summarize_results(dirname, verbose, stats_languages=None):
     )
 
     if verbose and len(lang_to_stats) > 0:
+
         def format_lang_stats(lang, lang_stats):
             # First, postprocess attributes for easier printing
             if lang_stats.completed_tests > 0:
@@ -712,9 +713,9 @@ def summarize_results(dirname, verbose, stats_languages=None):
                 )
             for i in range(tries):
                 num_passed = lang_to_passed_tests[lang][i]
-                setattr(lang_stats, f"pass_num_{i+1}", num_passed)
+                setattr(lang_stats, f"pass_num_{i + 1}", num_passed)
                 pass_rate = 100 * num_passed / float(lang_stats.completed_tests)
-                setattr(lang_stats, f"pass_rate_{i+1}", pass_rate)
+                setattr(lang_stats, f"pass_rate_{i + 1}", pass_rate)
 
             # Then format attributes into ready-to-print strings
             for attr in lang_stats.__dict__:


### PR DESCRIPTION
Hello! My previous [PR #27](https://github.com/dwash96/aider-ce/pull/27) had a slight bug. When you run `benchmark.py --stats --verbose` and view the stats broken down by language, It was using the wrong language to retrieve the pass rate.

Apologies for the error. I did some last second refactoring before submitting the PR, and didn't catch this bug in my manual spot tests.

This small PR fixes the mentioned bug by passing in `lang` as a parameter to retrieve the correct `num_passed` and `pass_rate` for each language.