### PR TITLE
Replace `shlex` with `oslex` within `grep` tool for Windows compatibility

### DIFF
--- a/aider/run_cmd.py
+++ b/aider/run_cmd.py
@@ -31,7 +31,7 @@ def get_windows_parent_process_name():
             if parent is None:
                 break
             parent_name = parent.name().lower()
-            if parent_name in ["pwsh.exe", "powershell.exe", "cmd.exe"]:
+            if parent_name in ["powershell.exe", "cmd.exe"]:
                 return parent_name
             current_process = parent
         return None
@@ -50,7 +50,7 @@ def run_cmd_subprocess(command, verbose=False, cwd=None, encoding=sys.stdout.enc
         # Determine the appropriate shell
         if platform.system() == "Windows":
             parent_process = get_windows_parent_process_name()
-            if parent_process in ["pwsh.exe", "powershell.exe"]:
+            if parent_process == "powershell.exe":
                 command = f"powershell -Command {command}"
 
         if verbose:


### PR DESCRIPTION
Per the [Python `shlex` documentation](https://docs.python.org/3/library/shlex.html):

> **Warning The shlex module is only designed for Unix shells.**
The [quote()](https://docs.python.org/3/library/shlex.html#shlex.quote) function is not guaranteed to be correct on non-POSIX compliant shells or shells from other operating systems such as Windows. Executing commands quoted by this module on such shells can open up the possibility of a command injection vulnerability.
Consider using functions that pass command arguments with lists such as [subprocess.run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) with shell=False.

~~There is a Windows equivalent called [mslex](https://github.com/smoofra/mslex) if we're ok adding another external dependency. Please advise and I will update.~~

We already use `oslex` which wraps `shlex` and `mslex`, so I've simply swapped that out.

Closes #52 once merged.
