### PR TITLE
Remove "aider" command so the original aider is still working after installation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dynamic = ["dependencies", "optional-dependencies", "version"]
 Homepage = "https://github.com/dwash96/aider-ce"
 
 [project.scripts]
-aider = "aider.main:main"
 aider-ce = "aider.main:main"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
When you install aider-ce with pipx (i bet also with uv), the "aider" command gets mapped to aider-ce. But i would like to distinct between aider-ce and aider, so there should only be a "aider-ce" command added by installing aider-ce.