### PR TITLE
More git tools

### DIFF
--- a/aider/coders/navigator_coder.py
+++ b/aider/coders/navigator_coder.py
@@ -57,18 +57,18 @@ from aider.tools.delete_line import _execute_delete_line
 from aider.tools.delete_lines import _execute_delete_lines
 from aider.tools.extract_lines import _execute_extract_lines
 from aider.tools.git import (
+    _execute_git_branch,
     _execute_git_diff,
     _execute_git_log,
+    _execute_git_remote,
     _execute_git_show,
     _execute_git_status,
-    _execute_git_branch,
-    _execute_git_remote,
+    git_branch_schema,
     git_diff_schema,
     git_log_schema,
+    git_remote_schema,
     git_show_schema,
     git_status_schema,
-    git_branch_schema,
-    git_remote_schema,
 )
 from aider.tools.grep import _execute_grep
 from aider.tools.indent_lines import _execute_indent_lines

--- a/aider/tools/__init__.py
+++ b/aider/tools/__init__.py
@@ -11,18 +11,18 @@ from .delete_line import _execute_delete_line, delete_line_schema
 from .delete_lines import _execute_delete_lines, delete_lines_schema
 from .extract_lines import _execute_extract_lines, extract_lines_schema
 from .git import (
+    _execute_git_branch,
     _execute_git_diff,
     _execute_git_log,
+    _execute_git_remote,
     _execute_git_show,
     _execute_git_status,
-    _execute_git_branch,
-    _execute_git_remote,
+    git_branch_schema,
     git_diff_schema,
     git_log_schema,
+    git_remote_schema,
     git_show_schema,
     git_status_schema,
-    git_branch_schema,
-    git_remote_schema,
 )
 from .grep import _execute_grep, grep_schema
 from .indent_lines import _execute_indent_lines, indent_lines_schema

--- a/aider/tools/git.py
+++ b/aider/tools/git.py
@@ -201,7 +201,7 @@ def _execute_git_remote(coder):
         remotes = coder.repo.repo.remotes
         if not remotes:
             return "No remotes configured."
-        
+
         result = []
         for remote in remotes:
             result.append(f"{remote.name}\t{remote.url}")


### PR DESCRIPTION
I have added branch and remote options to the git tool. 
Now we can list branches and remotes. 

Example prompts: `"which branch is the remote in sync with?"`, `"list the orphaned branches"`
This can work well in combination with the diff and show commands to grasp changes across branches. 

What we can't do with the git.py tool: merge, commit, switch branches and add/remove remotes... all potentially dangerous actions. 

I would love to add merge conflict handling especially but I am very aware of the complexity of this type of operation. During Covid I implemented a 3 way diff conflict resolution system for a client - resolving conflicts caused by collaborative editing of a shared spreadsheet. Anyway, I will look into it, and see if it can be done in a way that doesn't end up breaking peoples projects. In the meantime if people want to do destructive git operations they have the command.py

