### PR TITLE
fix: Strip whitespace from user input in preproc_user_input

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1331,6 +1331,9 @@ class Coder:
         if not inp:
             return
 
+        # Strip whitespace from beginning and end
+        inp = inp.strip()
+
         if self.commands.is_command(inp):
             if inp[0] in "!":
                 inp = f"/run {inp[1:]}"


### PR DESCRIPTION
this is again a minor ui thing - but just means that if your / command is not the first char it still gets interpreted correctly