### PR TITLE
Fix for Incomplete OpenRouter Model Listing

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -1189,6 +1189,19 @@ def check_for_dependencies(io, model_name):
         )
 
 
+def get_openrouter_models(verify_ssl=True):
+    import requests
+
+    response = requests.get(
+        "https://openrouter.ai/api/v1/models",
+        timeout=5,
+        verify=verify_ssl,
+    )
+    response.raise_for_status()
+    data = response.json()
+    return [m["id"] for m in data.get("data", [])]
+
+
 def fuzzy_match_models(name):
     name = name.lower()
 
@@ -1212,6 +1225,13 @@ def fuzzy_match_models(name):
 
         chat_models.add(fq_model)
         chat_models.add(orig_model)
+
+    try:
+        openrouter_models = get_openrouter_models(model_info_manager.verify_ssl)
+        for model in openrouter_models:
+            chat_models.add(f"openrouter/{model}")
+    except Exception:
+        pass
 
     chat_models = sorted(chat_models)
     # exactly matching model


### PR DESCRIPTION
Previously, Aider could not display all available models from OpenRouter, causing newer models like `openrouter/google/gemini-3-pro-preview` to be missing from the `/models` command output. This issue stemmed from Aider's reliance on static and cached model lists provided by the LiteLLM library, which were often outdated or incomplete.

The fix resolves this by implementing a direct, real-time API call to OpenRouter to fetch its complete and up-to-date model catalog, ensuring all available models are discoverable within Aider.

### The Problem: Reliance on Stale and Incomplete Data

Before this change, Aider's mechanism for discovering models had a critical flaw: it had no direct communication channel with OpenRouter to learn about its available models. Instead, it relied on two indirect sources:

1.  **LiteLLM's Built-in Model List (`litellm.model_cost`)**:
    *   Aider uses the LiteLLM library to interface with various LLM providers. LiteLLM includes a hard-coded dictionary of known models.
    *   **Limitation**: This list is static and only updates when the `litellm` package itself is updated. If OpenRouter added a new model, Aider would remain unaware of it until a new version of LiteLLM was released and integrated.

2.  **Cached LiteLLM Model Database**:
    *   Aider would download and cache a JSON file (`model_prices_and_context_window.json`) from LiteLLM's GitHub repository.
    *   **Limitation**: This file, also maintained by the LiteLLM team, is not updated in real-time. Furthermore, it does not guarantee the inclusion of every single model available on OpenRouter, especially those with complex routing names.

In essence, Aider was relying on second-hand information that was frequently out of sync with the ground truth at OpenRouter.

### The Solution: Direct API Integration

The code modification addresses this root cause by shifting from a passive, cache-based approach to an active, real-time query. This is achieved through three key changes:

1.  **Fetching Real-time Data (`get_openrouter_models`)**:
    *   A new function was introduced that sends a direct HTTP `GET` request to OpenRouter's official API endpoint: `https://openrouter.ai/api/v1/models`.
    *   This retrieves a definitive list of all models currently served by OpenRouter at the moment of the query.

2.  **Dynamic Search Pool Injection (`fuzzy_match_models`)**:
    *   The `fuzzy_match_models` function, which powers the model search, was modified to call the new `get_openrouter_models` function.
    *   It then injects the entire list of returned model IDs (prefixed with `openrouter/`) into the pool of searchable models. This ensures that as soon as OpenRouter adds a new model, Aider can find and use it without requiring a code update.