### PR TITLE
Add "preserve" option to line_endings setting.

### DIFF
--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -16,10 +16,10 @@ from aider.utils import ChdirTemporaryDirectory
 class TestInputOutput(unittest.TestCase):
     def test_line_endings_validation(self):
         # Test valid line endings
-        for ending in ["platform", "lf", "crlf"]:
+        for ending in ["platform", "lf", "crlf", "preserve"]:
             io = InputOutput(line_endings=ending)
             self.assertEqual(
-                io.newline, None if ending == "platform" else "\n" if ending == "lf" else "\r\n"
+                io.newline, None if ending in ("platform", "preserve") else "\n" if ending == "lf" else "\r\n"
             )
 
         # Test invalid line endings
@@ -30,6 +30,7 @@ class TestInputOutput(unittest.TestCase):
         self.assertIn("platform", str(cm.exception))
         self.assertIn("crlf", str(cm.exception))
         self.assertIn("lf", str(cm.exception))
+        self.assertIn("preserve", str(cm.exception))
 
     def test_no_color_environment_variable(self):
         with patch.dict(os.environ, {"NO_COLOR": "1"}):


### PR DESCRIPTION
Certain large repos that shall go unnamed contain mixed line-endings, so no existing setting will reliably prevent rewrites across the repo.

This PR adds an option to detect an individual file's newline before modifying it, and then uses that newline.