### PR TITLE
fix: prefer selector event loop on Windows to avoid asyncio Proactor issues

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -19,6 +19,10 @@ except ImportError:
 import importlib_resources
 import shtab
 from dotenv import load_dotenv
+
+if sys.platform == "win32":  # Windows asyncio fix. set_event_loop_policy deprecated in 3.16
+    if hasattr(asyncio, "set_event_loop_policy"):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 from prompt_toolkit.enums import EditingMode
 
 from aider import __version__, models, urls, utils
@@ -488,6 +492,14 @@ def custom_tracer(frame, event, arg):
 
 
 def main(argv=None, input=None, output=None, force_git_root=None, return_coder=False):
+    # Asyncio run workaround for Windows in Python 3.12+. Required from 3.16+
+    if sys.platform == "win32":
+        if sys.version_info >= (3, 12) and hasattr(asyncio, "SelectorEventLoop"):
+            return asyncio.run(
+                main_async(argv, input, output, force_git_root, return_coder),
+                loop_factory=asyncio.SelectorEventLoop,
+            )
+
     return asyncio.run(main_async(argv, input, output, force_git_root, return_coder))
 
 


### PR DESCRIPTION
The ProactorEventLoop doesn't play nice on windows with async. prompt_toolkit uses features that are note fully supported, which can be fixed by swapping to SelectorEventLoop. This adds a global guard (which will work but is slated for deprecation) and a local one (that may not fix async behavior by the time it's set depending on what other imports do). 

This fixed the issues I was having on windows, but it'll cause conflicts if asyncio.create_subprocess_exec() or asyncio.create_subprocess_shell() is ever added. 