### PR TITLE
fix: defer confirmation handling to resolve Windows event loop race condition

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1351,8 +1351,11 @@ class Coder:
                     try:
                         user_message = self.io.input_task.result()
 
+                        # Defer to confirmation handler to fix Windows event loop race.
+                        if self.io.confirmation_in_progress:
+                            pass
                         # Set user message for output task
-                        if not self.io.acknowledge_confirmation():
+                        elif not self.io.acknowledge_confirmation():
                             if user_message:
                                 self.user_message = user_message
                                 await self.auto_save_session()


### PR DESCRIPTION
When confirm_ask requests input, it reuses the underlying io.input_task. Since Coder.input_task is also awaiting io.input_task, both tasks wake up when the user types a response. 
1. confirm_ask receives the input. If it's invalid (e.g., "what?"), it rejects it and loops, asking again.
2. Coder.input_task also receives the input. Because confirm_ask rejected it, the confirmation_acknowledgement flag is not set.
3. Consequently, Coder.input_task treats the invalid confirmation response as a new chat message (user_message), triggering a new discussion workflow with the LLM.