### PR TITLE
chore(docs): use process substitution to avoid diff artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ LLMs are a part of our lives from here on out so join us in learning about and c
 * [Aider Original Documentation (still mostly applies)](https://aider.chat/)
 
 You can see a selection of the enhancements and updates by comparing the help output:
+
 ```bash
-aider --help > aider.help.txt
-cecli --help > cecli.help.txt
-diff aider.help.txt cecli.help.txt -uw --color
+diff -uw --color <(aider --help) <(cecli --help)
 ```
 
 ## Installation Instructions


### PR DESCRIPTION
Tiny documentation update here.

The suggested command replaces intermediate help output files with process substitution so `diff` operates on ephemeral streams instead. I can't imagine why someone would want to pollute their dir with `--help` output.