### PR TITLE
Auto-commit when finished

### DIFF
--- a/aider/coders/agent_coder.py
+++ b/aider/coders/agent_coder.py
@@ -1203,6 +1203,8 @@ class AgentCoder(Coder):
 
         if self.agent_finished:
             self.tool_usage_history = []
+            if self.files_edited_by_tools:
+                _ = await self.auto_commit(self.files_edited_by_tools)
             return True
 
         # Since we are no longer suppressing, the partial_response_content IS the final content.


### PR DESCRIPTION
When auto-commit is enabled, avoid leaving a dirty working tree at the end of an agent session.

Closes #280 