### PR TITLE
Suppress warning for the right Local MCP server name

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2741,7 +2741,7 @@ class Coder:
                 )
                 return (server.name, server_tools)
             except Exception as e:
-                if server.name != "unnamed-server" and server.name != "local_tools":
+                if server.name != "unnamed-server" and server.name != "Local":
                     self.io.tool_warning(f"Error initializing MCP server {server.name}: {e}")
                 return None
 


### PR DESCRIPTION
Suppress warning for the right Local MCP server name in base_coder.py