### PR TITLE
Fix: Environment variables prefix

### DIFF
--- a/cecli/args.py
+++ b/cecli/args.py
@@ -38,7 +38,7 @@ def get_parser(default_config_files, git_root):
         add_config_file_help=True,
         default_config_files=default_config_files,
         config_file_parser_class=configargparse.YAMLConfigFileParser,
-        auto_env_var_prefix="CECLI",
+        auto_env_var_prefix="CECLI_",
     )
     # List of valid edit formats for argparse validation & shtab completion.
     # Dynamically gather them from the registered coder classes so the list


### PR DESCRIPTION
Environment variables prefix should be "CECLI_" instead of "CECLI". Documentation is still not fixed (AIDER_)