### PR TITLE
Rename switch coder exception

### DIFF
--- a/cecli/coders/architect_coder.py
+++ b/cecli/coders/architect_coder.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from ..commands import SwitchCoder
+from ..commands import SwitchCoderSignal
 from .ask_coder import AskCoder
 from .base_coder import Coder
 
@@ -60,4 +60,4 @@ class ArchitectCoder(AskCoder):
         except Exception as e:
             self.io.tool_error(e)
 
-        raise SwitchCoder(main_model=self.main_model, edit_format="architect")
+        raise SwitchCoderSignal(main_model=self.main_model, edit_format="architect")

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -36,7 +36,7 @@ from rich.console import Console
 
 import cecli.prompts.utils.system as prompts
 from cecli import __version__, models, urls, utils
-from cecli.commands import Commands, SwitchCoder
+from cecli.commands import Commands, SwitchCoderSignal
 from cecli.exceptions import LiteLLMExceptions
 from cecli.helpers import coroutines
 from cecli.helpers.profiler import TokenProfiler
@@ -1370,7 +1370,7 @@ class Coder:
                     if task.exception():
                         raise task.exception()
 
-            except (SwitchCoder, SystemExit):
+            except (SwitchCoderSignal, SystemExit):
                 # Re-raise SwitchCoder to be handled by outer try block
                 raise
             except KeyboardInterrupt:
@@ -1461,7 +1461,7 @@ class Coder:
                 self.io.set_placeholder("")
                 self.keyboard_interrupt()
                 await self.io.stop_task_streams()
-            except (SwitchCoder, SystemExit):
+            except (SwitchCoderSignal, SystemExit):
                 raise
             except Exception as e:
                 if self.verbose or self.args.debug:
@@ -1496,7 +1496,7 @@ class Coder:
                     if self.io.output_task.done():
                         exception = self.io.output_task.exception()
                         if exception:
-                            if isinstance(exception, SwitchCoder):
+                            if isinstance(exception, SwitchCoderSignal):
                                 await self.io.output_task
                                 raise exception
 
@@ -1519,7 +1519,7 @@ class Coder:
                 self.io.stop_spinner()
                 self.keyboard_interrupt()
                 await self.io.stop_task_streams()
-            except (SwitchCoder, SystemExit):
+            except (SwitchCoderSignal, SystemExit):
                 raise
             except Exception as e:
                 if self.verbose or self.args.debug:

--- a/cecli/commands/__init__.py
+++ b/cecli/commands/__init__.py
@@ -18,7 +18,7 @@ from .context_blocks import ContextBlocksCommand
 from .context_management import ContextManagementCommand
 from .copy import CopyCommand
 from .copy_context import CopyContextCommand
-from .core import Commands, SwitchCoder
+from .core import Commands, SwitchCoderSignal
 from .diff import DiffCommand
 
 # Import and register commands
@@ -187,6 +187,6 @@ __all__ = [
     "CommandPrefixCommand",
     "LoadSkillCommand",
     "RemoveSkillCommand",
-    "SwitchCoder",
+    "SwitchCoderSignal",
     "Commands",
 ]

--- a/cecli/commands/add.py
+++ b/cecli/commands/add.py
@@ -137,9 +137,9 @@ class AddCommand(BaseCommand):
             map_tokens = 0
             map_mul_no_files = 1
 
-        from cecli.commands import SwitchCoder
+        from cecli.commands import SwitchCoderSignal
 
-        raise SwitchCoder(
+        raise SwitchCoderSignal(
             edit_format=coder.edit_format,
             summarize_from_coder=False,
             from_coder=coder,

--- a/cecli/commands/core.py
+++ b/cecli/commands/core.py
@@ -8,10 +8,27 @@ from cecli.helpers.file_searcher import handle_core_files
 from cecli.repo import ANY_GIT_ERROR
 
 
-class SwitchCoder(Exception):
+class SwitchCoderSignal(BaseException):
+    """
+     Signal to switch the current Coder instance to a new configuration.
+
+     This is NOT an error - it's a control flow signal used to propagate
+     coder switching requests up through the async call stack. It carries
+     the kwargs needed to create a new Coder instance.
+
+     Note: Inherits from BaseException (like KeyboardInterrupt and SystemExit)
+    to avoid being caught by generic `except Exception` handlers, making the
+     non-error nature of this signal explicit.
+
+     Attributes:
+         kwargs: Configuration dict passed to Coder.create() for the new instance
+         placeholder: Optional placeholder text for the input prompt
+    """
+
     def __init__(self, placeholder=None, **kwargs):
         self.kwargs = kwargs
         self.placeholder = placeholder
+        super().__init__()
 
 
 class Commands:
@@ -118,7 +135,7 @@ class Commands:
         except ANY_GIT_ERROR as err:
             self.io.tool_error(f"Unable to complete {cmd_name}: {err}")
             return
-        except SwitchCoder as e:
+        except SwitchCoderSignal as e:
             raise e
         except Exception as e:
             self.io.tool_error(f"Error executing command {cmd_name}: {str(e)}")

--- a/cecli/commands/drop.py
+++ b/cecli/commands/drop.py
@@ -82,7 +82,7 @@ class DropCommand(BaseCommand):
             return format_command_result(io, "drop", "Removed files from chat")
 
         finally:
-            # This mimics the SwitchCoder behavior in the original cmd_drop
+            # This mimics the SwitchCoderSignal behavior in the original cmd_drop
             if coder.repo_map:
                 map_tokens = coder.repo_map.max_map_tokens
                 map_mul_no_files = coder.repo_map.map_mul_no_files
@@ -90,10 +90,10 @@ class DropCommand(BaseCommand):
                 map_tokens = 0
                 map_mul_no_files = 1
 
-            # Raise SwitchCoder to trigger coder recreation
-            from . import SwitchCoder
+            # Raise SwitchCoderSignal to trigger coder recreation
+            from . import SwitchCoderSignal
 
-            raise SwitchCoder(
+            raise SwitchCoderSignal(
                 edit_format=coder.edit_format,
                 summarize_from_coder=False,
                 from_coder=coder,

--- a/cecli/commands/help.py
+++ b/cecli/commands/help.py
@@ -70,9 +70,9 @@ class HelpCommand(BaseCommand):
             map_tokens = 0
             map_mul_no_files = 1
 
-        from cecli.commands import SwitchCoder
+        from cecli.commands import SwitchCoderSignal
 
-        raise SwitchCoder(
+        raise SwitchCoderSignal(
             edit_format=coder.edit_format,
             summarize_from_coder=False,
             from_coder=help_coder,

--- a/cecli/commands/load.py
+++ b/cecli/commands/load.py
@@ -46,9 +46,9 @@ class LoadCommand(BaseCommand):
             try:
                 await commands_instance.run(cmd)
             except Exception as e:
-                # Handle SwitchCoder exception specifically
-                if type(e).__name__ == "SwitchCoder":
-                    # SwitchCoder is raised when switching between coder types (e.g., /architect, /ask).
+                # Handle SwitchCoderSignal exception specifically
+                if type(e).__name__ == "SwitchCoderSignal":
+                    # SwitchCoderSignal is raised when switching between coder types (e.g., /architect, /ask).
                     # This is expected behavior, not an error. But this gets in the way when running `/load` so we
                     # ignore it and continue processing remaining commands.
                     should_raise_at_end = e

--- a/cecli/commands/model.py
+++ b/cecli/commands/model.py
@@ -73,23 +73,25 @@ class ModelCommand(BaseCommand):
                 coder.coder_commit_hashes = temp_coder.coder_commit_hashes
 
                 # Restore the original model configuration
-                from cecli.commands import SwitchCoder
+                from cecli.commands import SwitchCoderSignal
 
-                raise SwitchCoder(main_model=original_main_model, edit_format=original_edit_format)
+                raise SwitchCoderSignal(
+                    main_model=original_main_model, edit_format=original_edit_format
+                )
             except Exception as e:
                 # If there's an error, still restore the original model
-                if not isinstance(e, SwitchCoder):
+                if not isinstance(e, SwitchCoderSignal):
                     io.tool_error(str(e))
-                    raise SwitchCoder(
+                    raise SwitchCoderSignal(
                         main_model=original_main_model, edit_format=original_edit_format
                     )
                 else:
-                    # Re-raise SwitchCoder if that's what was thrown
+                    # Re-raise SwitchCoderSignal if that's what was thrown
                     raise
         else:
-            from cecli.commands import SwitchCoder
+            from cecli.commands import SwitchCoderSignal
 
-            raise SwitchCoder(main_model=model, edit_format=new_edit_format)
+            raise SwitchCoderSignal(main_model=model, edit_format=new_edit_format)
 
     @classmethod
     def get_completions(cls, io, coder, args) -> List[str]:

--- a/cecli/commands/reset.py
+++ b/cecli/commands/reset.py
@@ -40,10 +40,10 @@ class ResetCommand(BaseCommand):
                 map_tokens = 0
                 map_mul_no_files = 1
 
-            # Raise SwitchCoder to trigger coder recreation
-            from . import SwitchCoder
+            # Raise SwitchCoderSignal to trigger coder recreation
+            from . import SwitchCoderSignal
 
-            raise SwitchCoder(
+            raise SwitchCoderSignal(
                 edit_format=coder.edit_format,
                 summarize_from_coder=False,
                 from_coder=coder,

--- a/cecli/commands/utils/base_command.py
+++ b/cecli/commands/utils/base_command.py
@@ -96,9 +96,9 @@ class BaseCommand(ABC):
         """
         if not args.strip():
             # Switch to the corresponding chat mode
-            from cecli.commands import SwitchCoder
+            from cecli.commands import SwitchCoderSignal
 
-            raise SwitchCoder(edit_format=edit_format)
+            raise SwitchCoderSignal(edit_format=edit_format)
 
         from cecli.coders.base_coder import Coder
 
@@ -121,9 +121,9 @@ class BaseCommand(ABC):
         await new_coder.generate(user_message=user_msg, preproc=False)
         coder.coder_commit_hashes = new_coder.coder_commit_hashes
 
-        from cecli.commands import SwitchCoder
+        from cecli.commands import SwitchCoderSignal
 
-        raise SwitchCoder(
+        raise SwitchCoderSignal(
             main_model=original_main_model,
             edit_format=original_edit_format,
             done_messages=new_coder.done_messages,

--- a/cecli/commands/weak_model.py
+++ b/cecli/commands/weak_model.py
@@ -70,23 +70,25 @@ class WeakModelCommand(BaseCommand):
                 coder.coder_commit_hashes = temp_coder.coder_commit_hashes
 
                 # Restore the original model configuration
-                from cecli.commands import SwitchCoder
+                from cecli.commands import SwitchCoderSignal
 
-                raise SwitchCoder(main_model=original_main_model, edit_format=original_edit_format)
+                raise SwitchCoderSignal(
+                    main_model=original_main_model, edit_format=original_edit_format
+                )
             except Exception as e:
                 # If there's an error, still restore the original model
-                if not isinstance(e, SwitchCoder):
+                if not isinstance(e, SwitchCoderSignal):
                     io.tool_error(str(e))
-                    raise SwitchCoder(
+                    raise SwitchCoderSignal(
                         main_model=original_main_model, edit_format=original_edit_format
                     )
                 else:
-                    # Re-raise SwitchCoder if that's what was thrown
+                    # Re-raise SwitchCoderSignal if that's what was thrown
                     raise
         else:
-            from cecli.commands import SwitchCoder
+            from cecli.commands import SwitchCoderSignal
 
-            raise SwitchCoder(main_model=model, edit_format=coder.edit_format)
+            raise SwitchCoderSignal(main_model=model, edit_format=coder.edit_format)
 
     @classmethod
     def get_completions(cls, io, coder, args) -> List[str]:

--- a/cecli/main.py
+++ b/cecli/main.py
@@ -39,7 +39,7 @@ from cecli import __version__, models, urls, utils
 from cecli.args import get_parser
 from cecli.coders import Coder
 from cecli.coders.base_coder import UnknownEditFormat
-from cecli.commands import Commands, SwitchCoder
+from cecli.commands import Commands, SwitchCoderSignal
 from cecli.deprecated_args import handle_deprecated_model_args
 from cecli.format_settings import format_settings, scrub_sensitive_info
 from cecli.helpers.copypaste import ClipboardWatcher
@@ -1127,7 +1127,7 @@ async def main_async(argv=None, input=None, output=None, force_git_root=None, re
         io.tool_output()
         try:
             await coder.run(with_message=args.message)
-        except (SwitchCoder, KeyboardInterrupt, SystemExit):
+        except (SwitchCoderSignal, KeyboardInterrupt, SystemExit):
             pass
         return await graceful_exit(coder)
     if args.message_file:
@@ -1135,7 +1135,7 @@ async def main_async(argv=None, input=None, output=None, force_git_root=None, re
             message_from_file = io.read_text(args.message_file)
             io.tool_output()
             await coder.run(with_message=message_from_file)
-        except (SwitchCoder, KeyboardInterrupt, SystemExit):
+        except (SwitchCoderSignal, KeyboardInterrupt, SystemExit):
             pass
         except FileNotFoundError:
             io.tool_error(f"Message file not found: {args.message_file}")
@@ -1167,7 +1167,7 @@ async def main_async(argv=None, input=None, output=None, force_git_root=None, re
             coder.ok_to_warm_cache = bool(args.cache_keepalive_pings)
             await coder.run()
             return await graceful_exit(coder)
-        except SwitchCoder as switch:
+        except SwitchCoderSignal as switch:
             coder.ok_to_warm_cache = False
             if hasattr(switch, "placeholder") and switch.placeholder is not None:
                 io.placeholder = switch.placeholder

--- a/cecli/tui/worker.py
+++ b/cecli/tui/worker.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Optional
 
 from cecli.coders import Coder
-from cecli.commands import SwitchCoder
+from cecli.commands import SwitchCoderSignal
 
 # Suppress asyncio task destroyed warnings during shutdown
 logging.getLogger("asyncio").setLevel(logging.CRITICAL)
@@ -91,7 +91,7 @@ class CoderWorker:
                 break  # Normal exit
             except asyncio.CancelledError:
                 break
-            except SwitchCoder as switch:
+            except SwitchCoderSignal as switch:
                 # Handle chat mode switches (e.g., /chat-mode architect)
                 try:
                     kwargs = dict(io=self.coder.io, from_coder=self.coder)

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -9,7 +9,7 @@ import pytest
 
 from cecli.coders import Coder
 from cecli.coders.base_coder import FinishReasonLength, UnknownEditFormat
-from cecli.commands import SwitchCoder
+from cecli.commands import SwitchCoderSignal
 from cecli.dump import dump  # noqa: F401
 from cecli.io import InputOutput
 from cecli.models import Model
@@ -1382,7 +1382,7 @@ This command will print 'Hello, World!' to the console."""
                 new_callable=AsyncMock,
                 return_value=mock_editor,
             ):
-                with pytest.raises(SwitchCoder):
+                with pytest.raises(SwitchCoderSignal):
                     await coder.reply_completed()
 
                 io.confirm_ask.assert_called_once_with("Edit the files?", allow_tweak=False)
@@ -1407,7 +1407,7 @@ This command will print 'Hello, World!' to the console."""
                 new_callable=AsyncMock,
                 return_value=mock_editor,
             ):
-                with pytest.raises(SwitchCoder):
+                with pytest.raises(SwitchCoderSignal):
                     await coder.reply_completed()
 
                 io.confirm_ask.assert_called_once_with("Edit the files?", allow_tweak=False)

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -12,7 +12,7 @@ import git
 import pyperclip
 
 from cecli.coders import Coder
-from cecli.commands import Commands, SwitchCoder
+from cecli.commands import Commands, SwitchCoderSignal
 from cecli.dump import dump  # noqa: F401
 from cecli.io import InputOutput
 from cecli.models import Model
@@ -1795,10 +1795,10 @@ class TestCommands(TestCase):
         commands = Commands(io, coder)
 
         # Test switching the main model
-        with self.assertRaises(SwitchCoder) as context:
+        with self.assertRaises(SwitchCoderSignal) as context:
             commands.cmd_model("gpt-4")
 
-        # Check that the SwitchCoder exception contains the correct model configuration
+        # Check that the SwitchCoderSignal exception contains the correct model configuration
         self.assertEqual(context.exception.kwargs.get("main_model").name, "gpt-4")
         self.assertEqual(
             context.exception.kwargs.get("main_model").editor_model.name,
@@ -1822,10 +1822,10 @@ class TestCommands(TestCase):
         # Mock sanity check to avoid network calls
         with mock.patch("cecli.models.sanity_check_models"):
             # Test switching the main model to gpt-4 (default 'whole')
-            with self.assertRaises(SwitchCoder) as context:
+            with self.assertRaises(SwitchCoderSignal) as context:
                 commands.cmd_model("gpt-4")
 
-        # Check that the SwitchCoder exception contains the correct model configuration
+        # Check that the SwitchCoderSignal exception contains the correct model configuration
         self.assertEqual(context.exception.kwargs.get("main_model").name, "gpt-4")
         # Check that the edit format is preserved
         self.assertEqual(context.exception.kwargs.get("edit_format"), "udiff")
@@ -1836,7 +1836,7 @@ class TestCommands(TestCase):
         commands = Commands(io, coder)
 
         # Test switching the editor model
-        with self.assertRaises(SwitchCoder) as context:
+        with self.assertRaises(SwitchCoderSignal) as context:
             commands.cmd_editor_model("gpt-4")
 
         # Check that the SwitchCoder exception contains the correct model configuration
@@ -1853,10 +1853,10 @@ class TestCommands(TestCase):
         commands = Commands(io, coder)
 
         # Test switching the weak model
-        with self.assertRaises(SwitchCoder) as context:
+        with self.assertRaises(SwitchCoderSignal) as context:
             commands.cmd_weak_model("gpt-4")
 
-        # Check that the SwitchCoder exception contains the correct model configuration
+        # Check that the SwitchCoderSignal exception contains the correct model configuration
         self.assertEqual(context.exception.kwargs.get("main_model").name, self.GPT35.name)
         self.assertEqual(
             context.exception.kwargs.get("main_model").editor_model.name,
@@ -1875,10 +1875,10 @@ class TestCommands(TestCase):
         # Mock sanity check to avoid network calls
         with mock.patch("cecli.models.sanity_check_models"):
             # Test switching the main model to gpt-4 (default 'whole')
-            with self.assertRaises(SwitchCoder) as context:
+            with self.assertRaises(SwitchCoderSignal) as context:
                 commands.cmd_model("gpt-4")
 
-        # Check that the SwitchCoder exception contains the correct model configuration
+        # Check that the SwitchCoderSignal exception contains the correct model configuration
         self.assertEqual(context.exception.kwargs.get("main_model").name, "gpt-4")
         # Check that the edit format is updated to the new model's default
         self.assertEqual(context.exception.kwargs.get("edit_format"), "diff")
@@ -1894,7 +1894,7 @@ class TestCommands(TestCase):
         with mock.patch("cecli.coders.Coder.run") as mock_run:
             mock_run.return_value = canned_reply
 
-            with self.assertRaises(SwitchCoder):
+            with self.assertRaises(SwitchCoderSignal):
                 commands.cmd_ask(question)
 
             mock_run.assert_called_once()
@@ -2190,10 +2190,10 @@ class TestCommands(TestCase):
             commands_file = Path(repo_dir) / "test_commands.txt"
             commands_file.write_text("/ask Tell me about the code\n/model gpt-4\n")
 
-            # Mock run to raise SwitchCoder for /ask and /model
+            # Mock run to raise SwitchCoderSignal for /ask and /model
             async def mock_run(cmd):
                 if cmd.startswith(("/ask", "/model")):
-                    raise SwitchCoder()
+                    raise SwitchCoderSignal()
                 return None
 
             with mock.patch.object(commands, "run", side_effect=mock_run):
@@ -2243,7 +2243,7 @@ class TestCommands(TestCase):
             orig_coder.abs_fnames.add(str(editable_path))
             orig_coder.abs_read_only_fnames.add(str(other_ro_path))
 
-            # Simulate SwitchCoder by creating a new coder from the original one
+            # Simulate SwitchCoderSignal by creating a new coder from the original one
             new_coder = await Coder.create(from_coder=orig_coder)
             new_commands = new_coder.commands
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -13,7 +13,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from cecli.coders import Coder, CopyPasteCoder
-from cecli.commands import SwitchCoder
+from cecli.commands import SwitchCoderSignal
 from cecli.dump import dump
 from cecli.helpers.file_searcher import handle_core_files
 from cecli.io import InputOutput
@@ -263,7 +263,7 @@ def test_gitignore_files_flag_add_command(dummy_io, git_temp_dir, flag, should_i
     coder = main(args, **dummy_io, return_coder=True, force_git_root=git_temp_dir)
     try:
         asyncio.run(coder.commands.do_run("add", "ignored.txt"))
-    except SwitchCoder:
+    except SwitchCoderSignal:
         pass
     if should_include:
         assert abs_ignored_file in coder.abs_fnames

--- a/tests/help/test_help.py
+++ b/tests/help/test_help.py
@@ -73,13 +73,13 @@ class TestHelp:
         while time.time() - start_time < max_time:
             try:
                 # Try to run /help hi
-                # It may raise SwitchCoder (if help initialized) or return None (if help not initialized)
+                # It may raise SwitchCoderSignal (if help initialized) or return None (if help not initialized)
                 await commands.run("/help hi")
                 # If we get here, help initialization failed and command returned
-                # Don't assert SwitchCoder was raised
+                # Don't assert SwitchCoderSignal was raised
                 break
-            except cecli.commands.SwitchCoder:
-                # SwitchCoder was raised, help initialized successfully
+            except cecli.commands.SwitchCoderSignal:
+                # SwitchCoderSignal was raised, help initialized successfully
                 break
             except (ReadTimeout, ConnectionError):
                 await asyncio.sleep(delay)


### PR DESCRIPTION
Two things are being done in this PR:

- [Move commands.py to core.py under commands module. This removes hacky import behaviour](https://github.com/dwash96/aider-ce/commit/27780866274d5afb2e71cebf4bfac956763a45a8)
- [Rename SwitchCoder to SwitchCoderSignal + docstring to better detail project structure](https://github.com/dwash96/aider-ce/commit/248e868fbc4cf40a8caae7b5824551faf7dd7816)

View each commit since they are encapsulated.