### PR TITLE
Fix documentation link after renaming to cecli

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ LLMs are a part of our lives from here on out so join us in learning about and c
 
 ## Documentation/Other Notes:
 
-* [Agent Mode](https://github.com/dwash96/cecli/blob/main/aider/website/docs/config/agent-mode.md)
-* [MCP Configuration](https://github.com/dwash96/cecli/blob/main/aider/website/docs/config/mcp.md)
-* [TUI Configuration](https://github.com/dwash96/cecli/blob/main/aider/website/docs/config/tui.md)
-* [Skills](https://github.com/dwash96/cecli/blob/main/aider/website/docs/config/skills.md)
-* [Session Management](https://github.com/dwash96/cecli/blob/main/aider/website/docs/sessions.md)
+* [Agent Mode](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/agent-mode.md)
+* [MCP Configuration](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/mcp.md)
+* [TUI Configuration](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/tui.md)
+* [Skills](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/skills.md)
+* [Session Management](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/sessions.md)
 * [Custom Commands](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/custom-commands.md)
 * [Custom System Prompts](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/custom-system-prompts.md)
 * [Custom Tools](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/agent-mode.md#creating-custom-tools)
-* [Advanced Model Configuration](https://github.com/dwash96/cecli/blob/main/aider/website/docs/config/model-aliases.md#advanced-model-settings)
+* [Advanced Model Configuration](https://github.com/dwash96/cecli/blob/main/cecli/website/docs/config/model-aliases.md#advanced-model-settings)
 * [Aider Original Documentation (still mostly applies)](https://aider.chat/)
 
 You can see a selection of the enhancements and updates by comparing the help output:


### PR DESCRIPTION
Links in documentation are broken after `aider` folder was renamed to `cecli`.