### PR TITLE
Expand `~` when given an mcp servers file

### DIFF
--- a/cecli/mcp/utils.py
+++ b/cecli/mcp/utils.py
@@ -75,7 +75,7 @@ def _resolve_mcp_config_path(file_path, io, verbose=False):
         return None
 
     # If the path is absolute or already exists, use it as-is
-    path = Path(file_path)
+    path = Path(file_path).expanduser()
     if path.is_absolute() or path.exists():
         return str(path.resolve())
 


### PR DESCRIPTION
Now we can put paths like `~/.config/mcp/mcp.json` in the conf.yml file for `mcp-servers-file`.
Before this would fail to resolve correctly.