### PR TITLE
[gh-413] Filter completion candidates for `/add` command

### DIFF
--- a/cecli/commands/add.py
+++ b/cecli/commands/add.py
@@ -207,6 +207,7 @@ class AddCommand(BaseCommand):
         """Get completion options for add command."""
         files = set(coder.get_all_relative_files())
         files = files - set(coder.get_inchat_relative_files())
+        files = [file for file in files if args.lower() in file.lower()]
         files = [quote_filename(fn) for fn in files]
         return files
 


### PR DESCRIPTION
Closes #413 

I'm probably missing context here b/c not sure how it broke all of a sudden and git history says this file hasn't been touched (from the last release)