### PR TITLE
CLI-6: Fix Keyboard Interruption Handling

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -328,6 +328,7 @@ class Coder:
         uuid="",
     ):
         # initialize from args.map_cache_dir
+        self.interrupt_event = asyncio.Event()
         self.uuid = generate_unique_id()
         if uuid:
             self.uuid = uuid
@@ -1735,6 +1736,7 @@ class Coder:
 
         self.io.tool_warning("\n\n^C KeyboardInterrupt")
 
+        self.interrupt_event.set()
         self.last_keyboard_interrupt = time.time()
 
     # Old summarization system removed - using context compaction logic instead
@@ -3039,6 +3041,7 @@ class Coder:
             return prompts.added_files.format(fnames=", ".join(added_fnames))
 
     async def send(self, messages, model=None, functions=None, tools=None):
+        self.interrupt_event.clear()
         self.got_reasoning_content = False
         self.ended_reasoning_content = False
 
@@ -3058,15 +3061,33 @@ class Coder:
         self.token_profiler.start()
 
         try:
-            hash_object, completion = await model.send_completion(
-                messages,
-                functions,
-                self.stream,
-                self.temperature,
-                # This could include any tools, but for now it is just MCP tools
-                tools=tools,
-                override_kwargs=self.model_kwargs.copy(),
+            completion_task = asyncio.create_task(
+                model.send_completion(
+                    messages,
+                    functions,
+                    self.stream,
+                    self.temperature,
+                    # This could include any tools, but for now it is just MCP tools
+                    tools=tools,
+                    override_kwargs=self.model_kwargs.copy(),
+                )
             )
+            interrupt_task = asyncio.create_task(self.interrupt_event.wait())
+
+            done, pending = await asyncio.wait(
+                {completion_task, interrupt_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if interrupt_task in done:
+                completion_task.cancel()
+                try:
+                    await completion_task
+                except asyncio.CancelledError:
+                    pass
+                raise KeyboardInterrupt
+
+            hash_object, completion = completion_task.result()
             self.chat_completion_call_hashes.append(hash_object.hexdigest())
 
             if not isinstance(completion, ModelResponse):

--- a/cecli/io.py
+++ b/cecli/io.py
@@ -758,6 +758,11 @@ class InputOutput:
             print()
 
     def interrupt_input(self):
+        if self.coder:
+            coder = self.coder()
+            if coder and hasattr(coder, "interrupt_event"):
+                coder.interrupt_event.set()
+
         if self.prompt_session and self.prompt_session.app:
             # Store any partial input before interrupting
             self.placeholder = self.prompt_session.app.current_buffer.text


### PR DESCRIPTION
## Summary

This PR implements proper keyboard interruption handling for LLM completions and IO operations.

## Changes Made

### 1. Interruptible LLM Completion (`cecli/coders/base_coder.py`)
- Added `interrupt_event` asyncio.Event() to track interruptions
- Implemented proper cancellation of LLM completion tasks when interrupted using `asyncio.wait()` with `FIRST_COMPLETED`
- Added proper cleanup for cancelled tasks to prevent resource leaks
- Ensures clean KeyboardInterrupt handling without partial responses or garbage errors

### 2. IO Interruption Propagation (`cecli/io.py`)
- Added mechanism to propagate interruption events to the coder
- Ensures that keyboard interrupts are properly handled at the IO level
- Maintains prompt session state during interruptions

## Problem Solved

Before this change, keyboard interrupts could leave the system in an inconsistent state, potentially causing:
- Partial LLM responses being processed
- Resource leaks from incomplete async operations
- Garbage error messages
- Inconsistent prompt session state

## Testing

The changes have been tested with:
- Manual keyboard interruption during LLM completions
- Verification of clean state after interruption
- Confirmation that prompt sessions maintain consistency

## Related Issue

Fixes CLI-6: Improve interruption handling to prevent garbage errors and partial responses.