### PR TITLE
Error in UpdateTodoList: [Errno 2] No such file or directory fix

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -4003,7 +4003,8 @@ class Coder:
         return edits
 
     def local_agent_folder(self, path):
-        os.makedirs(f".cecli/agents/{GLOBAL_DATE}/{self.uuid}", exist_ok=True)
+        abs_path = self.abs_root_path(f".cecli/agents/{GLOBAL_DATE}/{self.uuid}/path")
+        os.makedirs(abs_path, exist_ok=True)
 
         stripped = path.lstrip("/")
         return f".cecli/agents/{GLOBAL_DATE}/{self.uuid}/{stripped}"


### PR DESCRIPTION
On Win11 I started cecli with option '--subtree-only' in a subfolder of my repo. Agent failed to update todo list with error message:

```
Unable to write file C:\SandBox\repo1\.cecli\agents\2026-04-29\cab13e36-34e7-433a-8431-4147676a23ca\todo.txt: [Errno 2] No such file or                       ▃
   directory:
   'C:\\SandBox\\repo1\\.cecli\\agents\\2026-04-29\\cab13e36-34e7-433a-8431-4147676a23ca\\todo.txt'
   Error in UpdateTodoList: [Errno 2] No such file or directory:
   'C:\\SandBox\\repo1\\.cecli\\agents\\2026-04-29\\cab13e36-34e7-433a-8431-4147676a23ca\\todo.txt'
   Traceback (most recent call last):
     File "C:\Python\cecli-dev-venv\Lib\site-packages\cecli\tools\update_todo_list.py", line 158, in execute
       coder.io.write_text(abs_path, new_content)
     File "C:\Python\cecli-dev-venv\Lib\site-packages\cecli\io.py", line 737, in write_text
       with open(str(filename), "w", encoding=self.encoding, newline=newline) as f:
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   FileNotFoundError: [Errno 2] No such file or directory:
   'C:\\SandBox\\repo1\\.cecli\\agents\\2026-04-29\\cab13e36-34e7-433a-8431-4147676a23ca\\todo.txt'
```

This commit fix the error for me.