### PR TITLE
CLI-19: Skip gitignored files in autocommit

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -3723,7 +3723,7 @@ class Coder:
             self.check_for_dirty_commit(path)
             return True
 
-        if self.repo and self.repo.git_ignored_file(path):
+        if self.repo and self.repo.git_ignored_file(path) and not self.add_gitignore_files:
             self.io.tool_warning(f"Skipping edits to {path} that matches gitignore spec.")
             return
 
@@ -3742,7 +3742,8 @@ class Coder:
                 # actually already part of the repo.
                 # But let's only add if we need to, just to be safe.
                 if need_to_add:
-                    self.repo.repo.git.add(full_path)
+                    if not (self.add_gitignore_files and self.repo.git_ignored_file(path)):
+                        self.repo.repo.git.add(full_path)
 
             self.abs_fnames.add(full_path)
             self.check_added_files()
@@ -3756,7 +3757,8 @@ class Coder:
             return
 
         if need_to_add:
-            self.repo.repo.git.add(full_path)
+            if not (self.add_gitignore_files and self.repo.git_ignored_file(path)):
+                self.repo.repo.git.add(full_path)
 
         self.abs_fnames.add(full_path)
         self.check_added_files()

--- a/cecli/repo.py
+++ b/cecli/repo.py
@@ -352,10 +352,8 @@ class GitRepo:
             for fname in fnames:
                 try:
                     # Check if file is git-ignored before trying to add
-                    rel_fname = self.get_rel_fname(fname)
-                    # Only skip git-ignored files if add_gitignore_files is enabled
-                    # and we have access to coder context
-                    if coder and hasattr(coder, 'add_gitignore_files') and coder.add_gitignore_files:
+                    if coder and hasattr(coder, "add_gitignore_files") and coder.add_gitignore_files:
+                        rel_fname = coder.get_rel_fname(fname)
                         if self.git_ignored_file(rel_fname):
                             # Skip git-ignored files when add_gitignore_files is enabled
                             continue

--- a/cecli/repo.py
+++ b/cecli/repo.py
@@ -353,7 +353,7 @@ class GitRepo:
                 try:
                     # Check if file is git-ignored before trying to add
                     if coder and hasattr(coder, "add_gitignore_files") and coder.add_gitignore_files:
-                        rel_fname = coder.get_rel_fname(fname)
+                        rel_fname = self.get_rel_fname(fname)
                         if self.git_ignored_file(rel_fname):
                             # Skip git-ignored files when add_gitignore_files is enabled
                             continue
@@ -403,6 +403,12 @@ class GitRepo:
             return os.path.relpath(self.repo.git_dir, os.getcwd())
         except (ValueError, OSError):
             return self.repo.git_dir
+
+    def get_rel_fname(self, fname):
+        try:
+            return os.path.relpath(fname, self.root)
+        except ValueError:
+            return fname
 
     async def get_commit_message(self, diffs, context, user_language=None):
         diffs = "# Diffs:\n" + diffs

--- a/cecli/repo.py
+++ b/cecli/repo.py
@@ -348,12 +348,26 @@ class GitRepo:
             cmd.append("--no-verify")
         if fnames:
             fnames = [str(self.abs_root_path(fn)) for fn in fnames]
+            added_fnames = []
             for fname in fnames:
                 try:
+                    # Check if file is git-ignored before trying to add
+                    rel_fname = self.get_rel_fname(fname)
+                    # Only skip git-ignored files if add_gitignore_files is enabled
+                    # and we have access to coder context
+                    if coder and hasattr(coder, 'add_gitignore_files') and coder.add_gitignore_files:
+                        if self.git_ignored_file(rel_fname):
+                            # Skip git-ignored files when add_gitignore_files is enabled
+                            continue
                     self.repo.git.add(fname)
+                    added_fnames.append(fname)
                 except ANY_GIT_ERROR as err:
                     self.io.tool_error(f"Unable to add {fname}: {err}")
-            cmd += ["--"] + fnames
+            if added_fnames:
+                cmd += ["--"] + added_fnames
+            else:
+                # No files to commit (all were git-ignored or failed to add)
+                return
         else:
             cmd += ["-a"]
 

--- a/cecli/repo.py
+++ b/cecli/repo.py
@@ -352,7 +352,11 @@ class GitRepo:
             for fname in fnames:
                 try:
                     # Check if file is git-ignored before trying to add
-                    if coder and hasattr(coder, "add_gitignore_files") and coder.add_gitignore_files:
+                    if (
+                        coder
+                        and hasattr(coder, "add_gitignore_files")
+                        and coder.add_gitignore_files
+                    ):
                         rel_fname = self.get_rel_fname(fname)
                         if self.git_ignored_file(rel_fname):
                             # Skip git-ignored files when add_gitignore_files is enabled


### PR DESCRIPTION
## Summary
This PR implements CLI-19 to skip gitignored files during autocommit operations.

## Changes
- Modified autocommit logic to check if files are gitignored before including them
- Files that match .gitignore patterns are now excluded from autocommit
- This prevents unnecessary commits of files that should be ignored by git

## Testing
- Tested with various .gitignore patterns
- Verified that gitignored files are properly excluded from autocommit
- Confirmed that non-ignored files are still included in autocommit as expected

## Related Issue
CLI-19