### PR TITLE
fix: Prevent closing notifications from resetting prompt

### DIFF
--- a/cecli/io.py
+++ b/cecli/io.py
@@ -1707,12 +1707,16 @@ class InputOutput:
                         return f"zenity --notification --text='{NOTIFICATION_MESSAGE}'"
             return None  # No known notification tool found
         elif system == "Windows":
-            # PowerShell notification
+            # PowerShell toast notification
             return (
                 "powershell -command"
-                " \"[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms');"
-                f" [System.Windows.Forms.MessageBox]::Show('{NOTIFICATION_MESSAGE}',"
-                " 'cecli')\""
+                f" \"try {{ Add-Type -AssemblyName System.Runtime.WindowsRuntime; $null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] }} catch {{}}; "
+                f"$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
+                f"$toastXml = $template.GetXml(); "
+                f"$toastXml.GetElementsByTagName('text')[0].AppendChild($template.CreateTextNode('cecli')) > $null; "
+                f"$toastXml.GetElementsByTagName('text')[1].AppendChild($template.CreateTextNode('{NOTIFICATION_MESSAGE}')) > $null; "
+                f"$toast = [Windows.UI.Notifications.ToastNotification]::new($toastXml); "
+                f"[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('cecli').Show($toast)\""
             )
 
         return None  # Unknown system

--- a/cecli/io.py
+++ b/cecli/io.py
@@ -1710,7 +1710,7 @@ class InputOutput:
             # PowerShell toast notification
             return (
                 "powershell -command"
-                f" \"try {{ Add-Type -AssemblyName System.Runtime.WindowsRuntime; $null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] }} catch {{}}; "
+                f' "try {{ Add-Type -AssemblyName System.Runtime.WindowsRuntime; $null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] }} catch {{}}; '
                 f"$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
                 f"$toastXml = $template.GetXml(); "
                 f"$toastXml.GetElementsByTagName('text')[0].AppendChild($template.CreateTextNode('cecli')) > $null; "

--- a/cecli/io.py
+++ b/cecli/io.py
@@ -1708,16 +1708,23 @@ class InputOutput:
             return None  # No known notification tool found
         elif system == "Windows":
             # PowerShell toast notification
-            return (
-                "powershell -command"
-                f' "try {{ Add-Type -AssemblyName System.Runtime.WindowsRuntime; $null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] }} catch {{}}; '
-                f"$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
-                f"$toastXml = $template.GetXml(); "
-                f"$toastXml.GetElementsByTagName('text')[0].AppendChild($template.CreateTextNode('cecli')) > $null; "
-                f"$toastXml.GetElementsByTagName('text')[1].AppendChild($template.CreateTextNode('{NOTIFICATION_MESSAGE}')) > $null; "
-                f"$toast = [Windows.UI.Notifications.ToastNotification]::new($toastXml); "
-                f"[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('cecli').Show($toast)\""
+            ps_command = (
+                ' "try {{ Add-Type -AssemblyName System.Runtime.WindowsRuntime; $null ='
+                " [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications,"
+                " ContentType = WindowsRuntime] }} catch {{}}; "
+                "$template ="
+                " [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent"
+                "([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
+                "$toastXml = $template.GetXml(); "
+                "$toastXml.GetElementsByTagName('text')[0].AppendChild"
+                "($template.CreateTextNode('cecli')) > $null; "
+                f"$toastXml.GetElementsByTagName('text')[1].AppendChild"
+                f"($template.CreateTextNode('{NOTIFICATION_MESSAGE}')) > $null; "
+                "$toast = [Windows.UI.Notifications.ToastNotification]::new($toastXml); "
+                "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('cecli')"
+                '.Show($toast)"'
             )
+            return "powershell -command" + ps_command
 
         return None  # Unknown system
 

--- a/cecli/io.py
+++ b/cecli/io.py
@@ -4,6 +4,7 @@ import base64
 import functools
 import json
 import os
+import platform
 import re
 import shutil
 import signal
@@ -1719,10 +1720,23 @@ class InputOutput:
     def _send_notification(self):
         if self.notifications_command:
             try:
-                result = subprocess.run(self.notifications_command, shell=True, capture_output=True)
-                if result.returncode != 0 and result.stderr:
-                    error_msg = result.stderr.decode("utf-8", errors="replace")
-                    self.tool_warning(f"Failed to run notifications command: {error_msg}")
+                # Use Popen to run the command in the background without waiting for it
+                # and without capturing its output, detaching it from the current terminal session.
+                kwargs = {
+                    "shell": True,
+                    "stdout": subprocess.DEVNULL,
+                    "stderr": subprocess.DEVNULL,
+                }
+                if platform.system() == "Windows":
+                    kwargs["creationflags"] = (
+                        subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS
+                    )
+                else:
+                    # For non-Windows systems, start a new session to detach
+                    kwargs["start_new_session"] = True
+
+                subprocess.Popen(self.notifications_command, **kwargs)
+
             except Exception as e:
                 self.tool_warning(f"Failed to run notifications command: {e}")
         else:


### PR DESCRIPTION
## Description
This PR addresses an issue where closing notifications would reset the prompt in the terminal. The changes ensure that notifications are properly detached from the terminal session, preventing any interference with the user's prompt.

## Changes Made
1. **Updated Notification Command for Windows**:
   - Replaced the `MessageBox` notification with a PowerShell toast notification that does not open a new terminal window.
   - This ensures a non-intrusive notification experience.

2. **Detached Notification Process**:
   - Modified the `_send_notification` method to use `subprocess.Popen` instead of `subprocess.run`.
   - Added platform-specific flags to detach the notification process:
     - For Windows: Used `CREATE_NO_WINDOW | DETACHED_PROCESS` to prevent the notification from opening a new terminal.
     - For non-Windows systems: Used `start_new_session=True` to detach the process.
   - Suppressed stdout and stderr to avoid cluttering the terminal.

## Related Commits
- `36c3c64d`: Use PowerShell toast notifications without opening a new terminal
- `0b77400d`: Detach notification process to prevent prompt reset

## Testing
- Tested on Windows to ensure notifications appear without resetting the prompt.
- Verified that notifications do not interfere with the terminal session.

## Impact
- Improves user experience by preventing prompt resets when notifications are closed.
- Ensures notifications are non-intrusive and do not disrupt the workflow.