### PR TITLE
cli-20: Formatting fixes across multiple files

### DIFF
--- a/cecli/coders/agent_coder.py
+++ b/cecli/coders/agent_coder.py
@@ -282,9 +282,7 @@ class AgentCoder(Coder):
                             content_parts.append(item.text)
                 return "".join(content_parts)
             except Exception as e:
-                self.io.tool_warning(
-                    (f"Executing {tool_name} on {server.name} failed:\nError: {e}")
-                )
+                self.io.tool_warning(f"Executing {tool_name} on {server.name} failed:\nError: {e}")
                 return f"Error executing tool call {tool_name}: {e}"
 
         result, interrupted = await interruptible(_exec_async(), self.interrupt_event)
@@ -381,7 +379,10 @@ class AgentCoder(Coder):
         try:
             result = '<context name="symbol_outline" from="agent">\n'
             result += "## Symbol Outline (Current Context)\n\n"
-            result += "Code definitions (classes, functions, methods, etc.) found in files currently in chat context."
+            result += (
+                "Code definitions (classes, functions, methods, etc.) found in files currently in"
+                " chat context."
+            )
             result += "\n\n"
             files_to_outline = list(self.abs_fnames) + list(self.abs_read_only_fnames)
             if not files_to_outline:
@@ -522,7 +523,10 @@ class AgentCoder(Coder):
                         )
                 if editable_files:
                     result += "\n".join(editable_files) + "\n\n"
-                    result += f"**Total editable: {len(editable_files)} files, {editable_tokens:,} tokens**\n\n"
+                    result += (
+                        f"**Total editable: {len(editable_files)} files,"
+                        f" {editable_tokens:,} tokens**\n\n"
+                    )
                 else:
                     result += "No editable files in context\n\n"
             if self.abs_read_only_fnames:
@@ -542,7 +546,10 @@ class AgentCoder(Coder):
                         )
                 if readonly_files:
                     result += "\n".join(readonly_files) + "\n\n"
-                    result += f"**Total read-only: {len(readonly_files)} files, {readonly_tokens:,} tokens**\n\n"
+                    result += (
+                        f"**Total read-only: {len(readonly_files)} files,"
+                        f" {readonly_tokens:,} tokens**\n\n"
+                    )
                 else:
                     result += "No read-only files in context\n\n"
             extra_tokens = sum(self.context_block_tokens.values())
@@ -730,7 +737,7 @@ class AgentCoder(Coder):
                 self.model_kwargs = {}
                 result_message = f"Error executing {tool_name}: {e}"
                 self.io.tool_error(
-                    (f"Error during {tool_name} execution: {e}\n{traceback.format_exc()}")
+                    f"Error during {tool_name} execution: {e}\n{traceback.format_exc()}"
                 )
             tool_responses.append(
                 {"role": "tool", "tool_call_id": tool_call.id, "content": result_message}
@@ -1020,8 +1027,8 @@ class AgentCoder(Coder):
             context_parts.append("## File Editing Tools Disabled")
             context_parts.append(
                 "File editing tools are currently disabled. Use `ReadRange` to determine the"
-                " current content hash prefixes needed to perform an edit and activate them when you"
-                " are ready to edit a file."
+                " current content hash prefixes needed to perform an edit and activate them when"
+                " you are ready to edit a file."
             )
 
         context_parts.append("\n\n")

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -1142,9 +1142,8 @@ class Coder:
                     "other_files": other_files,
                     "mentioned_fnames": mentioned_fnames,
                     "all_abs_files": all_abs_files,
-                    "read_only_count": (
-                        len(set(self.abs_read_only_fnames))
-                        + len(set(self.abs_read_only_stubs_fnames))
+                    "read_only_count": len(set(self.abs_read_only_fnames)) + len(
+                        set(self.abs_read_only_stubs_fnames)
                     ),
                 }
             )

--- a/cecli/io.py
+++ b/cecli/io.py
@@ -1718,7 +1718,7 @@ class InputOutput:
                 "$toastXml = $template.GetXml(); "
                 "$toastXml.GetElementsByTagName('text')[0].AppendChild"
                 "($template.CreateTextNode('cecli')) > $null; "
-                f"$toastXml.GetElementsByTagName('text')[1].AppendChild"
+                "$toastXml.GetElementsByTagName('text')[1].AppendChild"
                 f"($template.CreateTextNode('{NOTIFICATION_MESSAGE}')) > $null; "
                 "$toast = [Windows.UI.Notifications.ToastNotification]::new($toastXml); "
                 "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('cecli')"

--- a/cecli/sessions.py
+++ b/cecli/sessions.py
@@ -71,10 +71,9 @@ class SessionManager:
                     "file": session_file,
                     "model": session_data.get("model", "unknown"),
                     "edit_format": session_data.get("edit_format", "unknown"),
-                    "num_messages": (
-                        len(session_data.get("chat_history", {}).get("done_messages", []))
-                        + len(session_data.get("chat_history", {}).get("cur_messages", []))
-                    ),
+                    "num_messages": len(
+                        session_data.get("chat_history", {}).get("done_messages", [])
+                    ) + len(session_data.get("chat_history", {}).get("cur_messages", [])),
                     "num_files": (
                         len(session_data.get("files", {}).get("editable", []))
                         + len(session_data.get("files", {}).get("read_only", []))
@@ -198,11 +197,11 @@ class SessionManager:
             "editor_edit_format": self.coder.main_model.editor_edit_format,
             "edit_format": self.coder.edit_format,
             "chat_history": {
-                "done_messages": (
-                    ConversationService.get_manager(self.coder).get_messages_dict(MessageTag.DONE)
+                "done_messages": ConversationService.get_manager(self.coder).get_messages_dict(
+                    MessageTag.DONE
                 ),
-                "cur_messages": (
-                    ConversationService.get_manager(self.coder).get_messages_dict(MessageTag.CUR)
+                "cur_messages": ConversationService.get_manager(self.coder).get_messages_dict(
+                    MessageTag.CUR
                 ),
             },
             "files": {

--- a/cecli/tools/context_manager.py
+++ b/cecli/tools/context_manager.py
@@ -32,8 +32,7 @@ class Tool(BaseTool):
                         "type": "array",
                         "items": {"type": "string"},
                         "description": (
-                            "List of file paths to add as read-only. "
-                            "Limit to at most 2 at a time."
+                            "List of file paths to add as read-only. Limit to at most 2 at a time."
                         ),
                     },
                     "create": {

--- a/cecli/tools/read_range.py
+++ b/cecli/tools/read_range.py
@@ -22,17 +22,16 @@ class Tool(BaseTool):
             "name": "ReadRange",
             "description": (
                 "Get content hash prefixes of content between start and end patterns in files."
-                " Accepts an array of `show` objects, each with file_path, start_text,"
-                " end_text. These values must be lines from the content of the file."
-                " They can contain up to 3 lines but newlines should generally be avoided."
-                " Avoid using generic keywords and symbols."
-                "Special markers @000 and 000@ represent the file boundaries and can be"
-                " used for start_text and end_text for the first and last lines of"
-                " the file respectively. Avoid using both of the special markers together on non-empty files."
-                " Never use content hashes as the start_text and end_text values."
-                " Do not use the same pattern for the start_text and end_text."
-                " It is best to use function names, variable declarations and other block identifiers as "
-                " start_texts and end_texts."
+                " Accepts an array of `show` objects, each with file_path, start_text, end_text."
+                " These values must be lines from the content of the file. They can contain up to 3"
+                " lines but newlines should generally be avoided. Avoid using generic keywords and"
+                " symbols.Special markers @000 and 000@ represent the file boundaries and can be"
+                " used for start_text and end_text for the first and last lines of the file"
+                " respectively. Avoid using both of the special markers together on non-empty"
+                " files. Never use content hashes as the start_text and end_text values. Do not use"
+                " the same pattern for the start_text and end_text. It is best to use function"
+                " names, variable declarations and other block identifiers as  start_texts and"
+                " end_texts."
             ),
             "parameters": {
                 "type": "object",
@@ -127,7 +126,10 @@ class Tool(BaseTool):
                     error_outputs.append(
                         cls.format_error(
                             coder,
-                            f"Show operation {show_index + 1}: Provide both 'start_text' and 'end_text'.",
+                            (
+                                f"Show operation {show_index + 1}: Provide both 'start_text' and"
+                                " 'end_text'."
+                            ),
                             file_path,
                             start_text,
                             end_text,
@@ -284,7 +286,10 @@ class Tool(BaseTool):
                             error_outputs.append(
                                 cls.format_error(
                                     coder,
-                                    f"End pattern '{end_text}' not found in {file_path}. Do not search for it again.",
+                                    (
+                                        f"End pattern '{end_text}' not found in {file_path}. Do not"
+                                        " search for it again."
+                                    ),
                                     file_path,
                                     start_text,
                                     end_text,
@@ -297,7 +302,10 @@ class Tool(BaseTool):
                             error_outputs.append(
                                 cls.format_error(
                                     coder,
-                                    f"End pattern '{end_text}' not found after start pattern in {file_path}.",
+                                    (
+                                        f"End pattern '{end_text}' not found after start pattern in"
+                                        f" {file_path}."
+                                    ),
                                     file_path,
                                     start_text,
                                     end_text,
@@ -314,7 +322,7 @@ class Tool(BaseTool):
                         cls.format_error(
                             coder,
                             (
-                                f"Special markers cannot be used for ranges greater than 200 lines."
+                                "Special markers cannot be used for ranges greater than 200 lines."
                                 f" The resolved range is {e_idx - s_idx + 1} lines."
                                 " Pick more refined boundaries."
                             ),
@@ -466,7 +474,8 @@ class Tool(BaseTool):
                     )
                 if already_up_to_details:
                     coder.io.tool_output(
-                        f"Lines already up to date in context for {len(already_up_to_details)} operation(s)"
+                        "Lines already up to date in context for"
+                        f" {len(already_up_to_details)} operation(s)"
                     )
 
                     detail_str = "\n".join(already_up_to_details)


### PR DESCRIPTION
## Summary
This PR includes formatting fixes across multiple files in the cecli codebase.

## Changes Made

### Formatting fixes in:
- `cecli/coders/agent_coder.py` - Line wrapping and string formatting improvements
- `cecli/coders/base_coder.py` - Read-only count calculation formatting
- `cecli/io.py` - PowerShell toast notification string formatting
- `cecli/sessions.py` - Session message count calculation formatting
- `cecli/tools/context_manager.py` - Description string formatting
- `cecli/tools/read_range.py` - Multi-line description formatting and error message improvements

## Testing
- All changes are formatting-only (no functional changes)
- Code maintains the same behavior after refactoring

## Related Issue
- Branch: cli-20-save-restore-coder-mode