### PR TITLE
fix: Remove unconditional bell ring for auto-approved tool calls (cli-21)

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2780,7 +2780,6 @@ class Coder:
 
     def _print_tool_call_info(self, server_tool_calls):
         """Print information about an MCP tool call."""
-        self.io.ring_bell()
         # self.io.tool_output("Preparing to run MCP tools", bold=False)
 
         for server, tool_calls in server_tool_calls.items():


### PR DESCRIPTION
## Summary

This PR fixes an issue where notifications (bell rings) were being sent for every tool call in agent mode, even after the user had approved all tool calls with "(A)ll".

## Problem

In agent mode, after a user approves all tool calls with "(A)ll", `cecli` continued to send a notification (ring a bell) for every subsequent tool call that was automatically approved. This was annoying and unnecessary.

## Root Cause

The `_print_tool_call_info` method in `cecli/coders/base_coder.py` unconditionally called `self.io.ring_bell()` before checking if user confirmation was actually required. The confirmation check itself (`io.confirm_ask`) is smart enough not to prompt (and thus not to notify) if an "all" preference is already registered, but the bell had already been rung.

## Solution

Removed the unconditional `self.io.ring_bell()` call from the `_print_tool_call_info` method. The bell/notification is already correctly handled within the `io.confirm_ask` method, which is called right after `_print_tool_call_info`. This ensures the notification only triggers when the user is actually being prompted for confirmation.

## Changes

- `cecli/coders/base_coder.py`: Removed `self.io.ring_bell()` from `_print_tool_call_info` method

## Testing

User tested manually in agent mode:
1. Run `cecli` in agent mode
2. Issue a prompt that results in multiple tool calls
3. When prompted to "Run tools?", respond with "(A)ll"
4. Observe that subsequent, automatically-approved tool calls do not produce notifications

Fixes: cli-21