### PR TITLE
cli-23: Remove auto-compaction on clear/exit and other improvements

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -1573,9 +1573,14 @@ class Coder:
 
         try:
             if self.enable_context_compaction:
-                self.compact_context_completed = False
-                await self.compact_context_if_needed()
-                self.compact_context_completed = True
+                # Skip compaction if the user wants to clear or exit
+                # Compacting is wasteful since /clear will clear everything
+                # and /exit will exit the application
+                stripped = user_message.strip()
+                if stripped not in ("/clear", "/exit", "/quit"):
+                    self.compact_context_completed = False
+                    await self.compact_context_if_needed()
+                    self.compact_context_completed = True
 
             self.run_one_completed = False
             await self.run_one(user_message, preproc)

--- a/tests/commands/test_compaction.py
+++ b/tests/commands/test_compaction.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/commands/test_compaction.py
+++ b/tests/commands/test_compaction.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 # It's better to patch the Coder class where it's used if possible,
 # but for this test, we will instantiate it and mock its methods.

--- a/tests/commands/test_compaction.py
+++ b/tests/commands/test_compaction.py
@@ -1,0 +1,105 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+# It's better to patch the Coder class where it's used if possible,
+# but for this test, we will instantiate it and mock its methods.
+from cecli.coders.base_coder import Coder
+from cecli.io import InputOutput
+
+
+@pytest.fixture
+def mock_io():
+    """Fixture for a mocked InputOutput object."""
+    return MagicMock(spec=InputOutput)
+
+
+@pytest.fixture
+def mock_model():
+    """Fixture for a mocked model object."""
+    model = MagicMock()
+    model.info = {"max_input_tokens": 10000}
+    # Mock the name attribute that is used in Coder.create
+    model.name = "mock_model"
+    model.edit_format = "wholefile"
+    return model
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_compaction_for_clear_command(mock_io, mock_model):
+    """
+    Verify that compact_context_if_needed is NOT called for the /clear command.
+    """
+    # Arrange
+    coder = await Coder.create(main_model=mock_model, io=mock_io, edit_format="wholefile")
+    coder.enable_context_compaction = True
+    coder.compact_context_if_needed = AsyncMock()
+    coder.run_one = AsyncMock()
+    user_message = "/clear"
+
+    # Act
+    await coder.generate(user_message, preproc=True)
+
+    # Assert
+    coder.compact_context_if_needed.assert_not_called()
+    coder.run_one.assert_called_once_with(user_message, True)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_compaction_for_exit_command(mock_io, mock_model):
+    """
+    Verify that compact_context_if_needed is NOT called for the /exit command.
+    """
+    # Arrange
+    coder = await Coder.create(main_model=mock_model, io=mock_io, edit_format="wholefile")
+    coder.enable_context_compaction = True
+    coder.compact_context_if_needed = AsyncMock()
+    coder.run_one = AsyncMock()
+    user_message = "/exit"
+
+    # Act
+    await coder.generate(user_message, preproc=True)
+
+    # Assert
+    coder.compact_context_if_needed.assert_not_called()
+    coder.run_one.assert_called_once_with(user_message, True)
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_compaction_for_quit_command(mock_io, mock_model):
+    """
+    Verify that compact_context_if_needed is NOT called for the /quit command.
+    """
+    # Arrange
+    coder = await Coder.create(main_model=mock_model, io=mock_io, edit_format="wholefile")
+    coder.enable_context_compaction = True
+    coder.compact_context_if_needed = AsyncMock()
+    coder.run_one = AsyncMock()
+    user_message = "/quit"
+
+    # Act
+    await coder.generate(user_message, preproc=True)
+
+    # Assert
+    coder.compact_context_if_needed.assert_not_called()
+    coder.run_one.assert_called_once_with(user_message, True)
+
+
+@pytest.mark.asyncio
+async def test_generate_runs_compaction_for_regular_message(mock_io, mock_model):
+    """
+    Verify that compact_context_if_needed IS called for a regular message.
+    """
+    # Arrange
+    coder = await Coder.create(main_model=mock_model, io=mock_io, edit_format="wholefile")
+    coder.enable_context_compaction = True
+    coder.compact_context_if_needed = AsyncMock()
+    coder.run_one = AsyncMock()
+    user_message = "This is a regular message"
+
+    # Act
+    await coder.generate(user_message, preproc=True)
+
+    # Assert
+    coder.compact_context_if_needed.assert_called_once()
+    coder.run_one.assert_called_once_with(user_message, True)


### PR DESCRIPTION
### Summary
This PR implements the removal of auto-compaction when clearing or exiting the session, along with several other architectural refinements and reverts to synchronous operations for stability.

### Key Changes
- **Auto-Compaction Optimization**: Context compaction is now skipped when the user issues `/clear`, `/exit`, or `/quit` commands, preventing wasteful computation.
- **Synchronous Linter & Commands**: Reverted the Linter and shell command execution from async to synchronous (using `asyncio.to_thread` for `run_cmd`). This simplifies the codebase and improves reliability in interrupt handling.
- **Nested Delegation Removal**: Removed the `allow_nested_delegation` feature. Sub-agents are no longer permitted to delegate to further sub-agents.
- **MCP Lifecycle Management**: Enhanced the logic for disconnecting the \"Local\" MCP server when switching between Agent and non-Agent coders.
- **Notification Refinement**: Removed bell notifications and notification cooldown logic from the IO layer.
- **Testing**: Added comprehensive tests for the new compaction skipping logic and updated existing tests to reflect the synchronous linter changes.

### Why Needed
- Auto-compaction before a clear/exit was redundant and consumed unnecessary tokens/time.
- Reverting to synchronous operations for certain tasks reduces complexity and potential race conditions in the async event loop.
- Simplifying sub-agent capabilities ensures a more predictable agent hierarchy.