### PR TITLE
fix(tui): Handle KeyboardInterrupt during worker shutdown (CLI-38)

### DIFF
--- a/cecli/tui/worker.py
+++ b/cecli/tui/worker.py
@@ -79,6 +79,8 @@ class CoderWorker:
                         )
                     except RuntimeError:
                         pass  # Loop already stopped
+                    except KeyboardInterrupt:
+                        pass  # Loop already stopped
 
                 self.loop.close()
         except Exception:
@@ -180,6 +182,11 @@ class CoderWorker:
                 self.loop.call_soon_threadsafe(self.loop.stop)
             except RuntimeError:
                 # Loop may already be closed
+                pass
+            except KeyboardInterrupt:
+                # An interrupt was not caught within the async run loop.
+                # We'll just pass to allow the thread to exit gracefully
+                # without a scary traceback.
                 pass
             except KeyboardInterrupt:
                 # An interrupt was not caught within the async run loop.


### PR DESCRIPTION
This pull request resolves issue CLI-38.

It prevents a `KeyboardInterrupt` traceback that can occur during the shutdown of the Textual TUI, particularly when an interrupt is triggered while the `CoderWorker` is cleaning up its event loop.

### Changes
- Added a `try...except KeyboardInterrupt` block in `_cleanup_loop` within `cecli/tui/worker.py` to gracefully handle interrupts during task gathering.
- Added a `try...except KeyboardInterrupt` block in the `stop` method of `cecli/tui/worker.py` to prevent unhandled exceptions when stopping the event loop.

These changes ensure a cleaner and more robust shutdown process for the TUI.