### PR TITLE
Improve /add ignore feedback and Ollama keep_alive defaults

### DIFF
--- a/cecli/commands/add.py
+++ b/cecli/commands/add.py
@@ -13,6 +13,82 @@ from cecli.commands.utils.helpers import (
 from cecli.utils import is_image_file, run_fzf
 
 
+def _display_add_path(matched_file: str) -> str:
+    try:
+        label = os.path.relpath(matched_file)
+    except ValueError:
+        label = matched_file
+    if len(label) > 64:
+        label = f".../{os.path.basename(label)}"
+    return label
+
+
+def _git_repo_for_add_check(coder, matched_file: str):
+    """Resolve the GitRepo used for ignore checks (RepoSet-aware)."""
+    repo = coder.repo
+    if not repo:
+        return None, matched_file
+    if hasattr(repo, "repo_for_rel_path"):
+        git_repo = repo.repo_for_rel_path(matched_file)
+        try:
+            rel = repo.path_relative_to_repo(matched_file, git_repo)
+        except (ValueError, OSError):
+            rel = matched_file
+        return git_repo, rel
+    return repo, matched_file
+
+
+def _add_blocked_message(coder, matched_file: str) -> str | None:
+    """
+    Explain why /add refused a path. Distinguishes .gitignore vs .cecli.ignore when possible.
+    """
+    if not coder.repo or coder.add_gitignore_files:
+        return None
+    if not coder.repo.git_ignored_file(matched_file):
+        return None
+
+    display = _display_add_path(matched_file)
+    git_repo, rel = _git_repo_for_add_check(coder, matched_file)
+    if not git_repo:
+        return (
+            f"Can't add {display}: excluded by ignore rules for this session. "
+            "Confirm Settings → project folder is the git root for this file."
+        )
+
+    gitignore_hit = False
+    cecli_hit = False
+    if hasattr(git_repo, "_is_gitignored_by_pathspec"):
+        try:
+            gitignore_hit = bool(git_repo._is_gitignored_by_pathspec(rel))
+        except (ValueError, OSError):
+            gitignore_hit = False
+
+    ignore_file = getattr(git_repo, "cecli_ignore_file", None) or getattr(
+        git_repo, "aider_ignore_file", None
+    )
+    if ignore_file and Path(ignore_file).is_file() and hasattr(git_repo, "ignored_file_raw"):
+        try:
+            cecli_hit = bool(git_repo.ignored_file_raw(rel))
+        except (ValueError, OSError):
+            cecli_hit = False
+
+    if cecli_hit and not gitignore_hit:
+        return (
+            f"Can't add {display}: blocked by {Path(ignore_file).name} "
+            "(cecli ignore rules), not .gitignore."
+        )
+    if gitignore_hit:
+        return (
+            f"Can't add {display}: matched .gitignore under the session workspace. "
+            "If this is normal tracked source, check the project folder in Settings."
+        )
+    return (
+        f"Can't add {display}: excluded by ignore rules for this session "
+        "(.gitignore and/or cecli ignore). "
+        "Confirm the project folder is the git root that contains this file."
+    )
+
+
 class AddCommand(BaseCommand):
     NORM_NAME = "add"
     DESCRIPTION = "Add files to the chat so cecli can edit them or review them in detail"
@@ -84,12 +160,9 @@ class AddCommand(BaseCommand):
         for matched_file in sorted(all_matched_files):
             abs_file_path = coder.abs_root_path(matched_file)
 
-            if (
-                coder.repo
-                and coder.repo.git_ignored_file(matched_file)
-                and not coder.add_gitignore_files
-            ):
-                io.tool_error(f"Can't add {matched_file} which is in gitignore")
+            blocked = _add_blocked_message(coder, matched_file)
+            if blocked:
+                io.tool_error(blocked)
                 continue
 
             if abs_file_path in coder.abs_fnames:

--- a/cecli/models.py
+++ b/cecli/models.py
@@ -1206,9 +1206,12 @@ class Model(ModelSettings):
             kwargs["max_tokens"] = max_tokens
         if "max_tokens" in kwargs and kwargs["max_tokens"]:
             kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
-        if self.is_ollama() and "num_ctx" not in kwargs:
-            num_ctx = int(self.token_count(messages) * 1.25) + 8192
-            kwargs["num_ctx"] = num_ctx
+        if self.is_ollama():
+            # Ollama defaults to ~5m unload unless every request sets keep_alive (see Ollama API docs).
+            kwargs.setdefault("keep_alive", -1)
+            if "num_ctx" not in kwargs:
+                num_ctx = int(self.token_count(messages) * 1.25) + 8192
+                kwargs["num_ctx"] = num_ctx
         key = json.dumps(kwargs, sort_keys=True).encode()
         hash_object = hashlib.sha1(key)
         if "timeout" not in kwargs:


### PR DESCRIPTION
BrightVision desktop integration:

- /add: clearer errors when paths are blocked by .gitignore vs .cecli.ignore; RepoSet-aware paths for superproject workspaces.
- models: set keep_alive=-1 by default for Ollama chat requests so models stay loaded across turns (matches desktop Local LLM preload behavior).