### PR TITLE
fix(add): do not create files under host attachment staging paths

### DIFF
--- a/cecli/commands/add.py
+++ b/cecli/commands/add.py
@@ -13,6 +13,15 @@ from cecli.commands.utils.helpers import (
 from cecli.utils import is_image_file, run_fzf
 
 
+def _is_chat_attachment_staging_path(rel_norm: str) -> bool:
+    """
+    Host UIs (e.g. desktop IDEs) stage chat uploads under ``.<app>/attachments/``.
+    Do not offer to create missing paths there via ``/add`` — re-attach in the UI instead.
+    """
+    parts = rel_norm.replace("\\", "/").strip("/").split("/")
+    return len(parts) >= 2 and parts[0].startswith(".") and parts[1] == "attachments"
+
+
 class AddCommand(BaseCommand):
     NORM_NAME = "add"
     DESCRIPTION = "Add files to the chat so cecli can edit them or review them in detail"
@@ -70,6 +79,17 @@ class AddCommand(BaseCommand):
             confirm_fname = os.path.relpath(fname)
             if len(confirm_fname) > 64:
                 confirm_fname = f".../{os.path.basename(confirm_fname)}"
+
+            try:
+                rel_norm = os.path.relpath(fname, coder.root).replace("\\", "/")
+            except ValueError:
+                rel_norm = str(fname).replace("\\", "/")
+            if _is_chat_attachment_staging_path(rel_norm):
+                io.tool_error(
+                    f"Attachment not found: {confirm_fname}. "
+                    "Re-attach the file in chat instead of using /add on a staging path."
+                )
+                continue
 
             if await io.confirm_ask(
                 f"No files matched '{confirm_fname}'. Do you want to create this file?"

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -231,6 +231,19 @@ class TestCommands(TestCase):
         self.assertEqual(len(coder.abs_fnames), 1)
         self.assertTrue(fname.exists())
 
+    async def test_cmd_add_skips_create_on_attachment_staging_path(self):
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        from cecli.coders import Coder
+
+        coder = await Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        staging = Path(".cecli/attachments/missing.png")
+        commands.execute("add", str(staging))
+
+        self.assertEqual(len(coder.abs_fnames), 0)
+        self.assertFalse(staging.exists())
+
     async def test_cmd_add_drop_directory(self):
         # Initialize the Commands and InputOutput objects
         io = InputOutput(pretty=False, fancy_input=False, yes=False)


### PR DESCRIPTION
## Summary
- When `/add` targets a missing file under `.<app>/attachments/`, emit an error instead of prompting to create path segments.
- Fixes headless/desktop hosts (e.g. BrightVision) where failed image attach used to trigger many “create this file?” confirms.

## Test plan
- [ ] `pytest tests/basic/test_commands.py -k attachment_staging`
- [ ] BrightVision: attach image → no spurious create prompts; re-attach if staging file missing

## BrightVision pairing
Parent repo still bypasses `/add` for `.aider-vision/attachments/` in `bright_vision_core/session.py` (Vision layer, not cecli).

## Upstream
After merge here, open mirror PR to `cecli-dev/cecli` `v0.100.1` (or cherry-pick `8e92b87d3`).

 
 **PR Summary by Typo**
------------

#### Overview
This PR prevents the `add` command from creating new files within host attachment staging directories, guiding users to re-attach files via the chat UI instead.

#### Key Changes
- Introduced `_is_chat_attachment_staging_path` to identify host attachment staging paths (e.g., `.app/attachments/`).
- Modified the `AddCommand` to check if a file path is a staging path and, if so, prevent creation and display an informative error.
- Added a new test case to confirm that the `add` command correctly skips file creation for attachment staging paths.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 33 (100.0%)   |
| Total Changes | 33          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/add` command now prevents users from adding files found in chat attachment staging directories and displays guidance on re-attaching through chat.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Digital-Defiance/cecli/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->