### PR TITLE
fix(agent): guard missing verbose on headless args

### DIFF
--- a/cecli/coders/agent_coder.py
+++ b/cecli/coders/agent_coder.py
@@ -265,7 +265,8 @@ class AgentCoder(Coder):
 
     async def initialize_mcp_tools(self):
         if not self.mcp_manager:
-            self.mcp_manager = McpServerManager([], self.io, self.args.verbose)
+            verbose = getattr(self.args, "verbose", False) if self.args else False
+            self.mcp_manager = McpServerManager([], self.io, verbose)
 
         server_name = "Local"
         server = self.mcp_manager.get_server(server_name)


### PR DESCRIPTION
## Summary

BrightVision and other headless callers use `Coder.create(..., args=SimpleNamespace(...))` via `bright_vision_core.headless_args.default_headless_args()`, which did not always define every flag the interactive CLI sets.

`AgentCoder.initialize_mcp_tools()` accessed `self.args.verbose` unconditionally, which raised:

`AttributeError: 'types.SimpleNamespace' object has no attribute 'verbose'`

when users ran `/agent` through the Vision HTTP API.

This change uses `getattr(self.args, "verbose", False)` (and treats missing `args` as false), matching the pattern already used in `cecli/commands/run.py`.

## Not in scope

- Session encryption (#533)
- `/add` attachment staging paths (`fix/add-attachment-staging-paths`)

## Test plan

- [x] `python -m pytest tests/core/test_headless_agent.py -q` (BrightVision, with `source activate.sh`)
- [ ] `E2E_LLM=1 python -m pytest tests/core/test_agent_llm.py -q` (optional, needs Ollama)
- [ ] BrightVision: `yarn tauri dev` → Terminal Start → chat `/agent` short prompt → no `verbose` error in chat/terminal