### PR TITLE
fix(coder): Ollama-friendly empty LLM tool warning

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2306,6 +2306,16 @@ class Coder(metaclass=UsageMeta):
     def get_active_model(self):
         return self.main_model
 
+    def empty_llm_tool_warning(self) -> str:
+        """Ollama-friendly copy for local models; cloud hint otherwise."""
+        name = str(getattr(getattr(self, "main_model", None), "name", "") or "")
+        if "ollama" in name.lower():
+            return (
+                "Empty response from the local model (Ollama). "
+                "The model may have timed out, unloaded, or hit context limits."
+            )
+        return "Empty response received from LLM. Check API keys, quota, or provider status."
+
     async def send_message(self, inp):
         # Notify IO that LLM processing is starting
         self.io.llm_started()
@@ -3363,7 +3373,7 @@ class Coder(metaclass=UsageMeta):
             and not len(self.partial_response_tool_calls)
             and not len(self.partial_response_reasoning_content)
         ):
-            self.io.tool_warning("Empty response received from LLM. Check your provider account?")
+            self.io.tool_warning(self.empty_llm_tool_warning())
 
         self.io.assistant_output(show_resp, pretty=self.show_pretty())
 
@@ -3520,7 +3530,7 @@ class Coder(metaclass=UsageMeta):
             return
 
         if not received_content and len(self.partial_response_tool_calls) == 0:
-            self.io.tool_warning("Empty response received from LLM. Check your provider account?")
+            self.io.tool_warning(self.empty_llm_tool_warning())
 
     def consolidate_chunks(self):
         if self.partial_response_consolidated:


### PR DESCRIPTION
## Summary
Replace legacy “Check your provider account?” tool warnings when the model returns no tokens or tool calls. Ollama/local models get a timeout/context hint; cloud models keep an API-keys/quota message.

## Scope
- One file: `cecli/coders/base_coder.py` (`empty_llm_tool_warning()`)
- Cherry-picked from integration work (`818f046ca` on `dev-integration`)

## Why
BrightVision already rewrites this in the React UI; this aligns **tool_output** / terminal paths for local LLM dogfood.

## Test plan
- [ ] `pytest` (or CI) on fork
- [ ] Optional: trigger empty Ollama reply in headless session and confirm warning text
 
 **PR Summary by Typo**
------------

#### Overview
This PR refines the warning message displayed when an LLM returns an empty response, making it more informative and specific, especially for users interacting with local Ollama models.

#### Key Changes
- Added a new method `empty_llm_tool_warning` to `base_coder.py` to generate context-specific warning messages.
- The warning message now differentiates between Ollama models (suggesting timeouts, unloads, or context limits) and other LLMs (suggesting API key, quota, or provider issues).
- Updated calls to `self.io.tool_warning` in `show_send_output` and `show_send_output_stream` to utilize the new dynamic warning message.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 10 (83.3%)    |
| Rework      | 2 (16.7%)     |
| Total Changes | 12            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for empty AI model responses with intelligent, provider-specific guidance. Users now receive tailored hints appropriate to their model configuration, helping troubleshoot issues more effectively.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Digital-Defiance/cecli/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->