### PR TITLE
fix: Catch BaseException in worker thread to prevent tracebacks on interruption

### DIFF
--- a/cecli/models.py
+++ b/cecli/models.py
@@ -1378,6 +1378,11 @@ class Model(ModelSettings):
                 continue
             except AttributeError:
                 return None
+            except KeyboardInterrupt:
+                # An interrupt was not caught within the async run loop.
+                # We'll just pass to allow the thread to exit gracefully
+                # without a scary traceback.
+                pass
 
     def model_error_response(self):
         return litellm.ModelResponse(

--- a/cecli/tui/worker.py
+++ b/cecli/tui/worker.py
@@ -49,10 +49,9 @@ class CoderWorker:
 
         try:
             self.loop.run_until_complete(self._async_run())
-        except asyncio.CancelledError:
-            pass
-        except RuntimeError:
-            # Event loop stopped - this is expected during shutdown
+        except BaseException:
+            # Catch anything that could bring down the thread, and just let it exit.
+            # This includes KeyboardInterrupt, SystemExit, etc.
             pass
         finally:
             self._cleanup_loop()
@@ -182,11 +181,6 @@ class CoderWorker:
                 self.loop.call_soon_threadsafe(self.loop.stop)
             except RuntimeError:
                 # Loop may already be closed
-                pass
-            except KeyboardInterrupt:
-                # An interrupt was not caught within the async run loop.
-                # We'll just pass to allow the thread to exit gracefully
-                # without a scary traceback.
                 pass
             except KeyboardInterrupt:
                 # An interrupt was not caught within the async run loop.


### PR DESCRIPTION
## Summary

Fixes an issue where `KeyboardInterrupt` exceptions during async completion calls would produce ugly tracebacks and potentially crash the TUI worker thread.

## Changes

### `cecli/tui/worker.py`
- Consolidated exception handling in `CoderWorker.run()` to catch `BaseException` instead of only `asyncio.CancelledError` and `RuntimeError`. This ensures `KeyboardInterrupt`, `SystemExit`, and any other unexpected exceptions don't crash the worker thread.
- Removed the now-redundant `except KeyboardInterrupt` block in `_async_run()` since the outer `BaseException` catch in `run()` already handles it.

### `cecli/models.py`
- Added `except KeyboardInterrupt` handler in the model's async completion loop to gracefully exit without a traceback when an interrupt occurs mid-request.

## Related Issues
- Jira: CLI-29
- Previous attempts: cli-29-interruption-exception-take-1 through take-4