### PR TITLE
fix: resolve AttributeError in TUI.show_error

### DIFF
--- a/cecli/tui/app.py
+++ b/cecli/tui/app.py
@@ -722,7 +722,8 @@ class TUI(App):
 
     def show_error(self, message, agent_name: str | None = None):
         """Show an error message in the status bar."""
-        self.status_bar.show_notification(
+        status_bar = self.query_one("#status-bar", StatusBar)
+        status_bar.show_notification(
             message, severity="error", timeout=5, agent_name=agent_name
         )
 

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -197,9 +197,12 @@ def test_handle_output_message_error_with_agent_name(tui_instance, monkeypatch):
         if isinstance(selector, type):
             name = selector.__name__
         else:
-            if "," in selector or "#" in selector:
+            if selector == "#input" or selector == "#input, InputArea":
                 return mock_input_area
-            return mock_footer
+            elif selector == "#status-bar" or selector == "#status-bar, StatusBar":
+                return mock_status_bar
+            name = "MainFooter"  # Default fallback
+
         mapping = {
             "MainFooter": mock_footer,
             "StatusBar": mock_status_bar,
@@ -216,9 +219,6 @@ def test_handle_output_message_error_with_agent_name(tui_instance, monkeypatch):
     mock_coder.uuid = "primary_uuid"
     tui_instance.worker = MagicMock()
     tui_instance.worker.coder = mock_coder
-
-    # Stub status_bar reference
-    tui_instance.status_bar = mock_status_bar
 
     # Mock AgentService - unknown UUID should return None (no prefix)
     monkeypatch.setattr(
@@ -238,4 +238,28 @@ def test_handle_output_message_error_with_agent_name(tui_instance, monkeypatch):
         severity="error",
         timeout=5,
         agent_name=None,
+    )
+
+
+def test_show_error_uses_query_one(tui_instance):
+    """
+    Test that show_error uses query_one to get the status bar and show a notification.
+    """
+    mock_status_bar = MagicMock()
+    tui_instance.query_one = MagicMock(return_value=mock_status_bar)
+
+    # Import StatusBar for the assertion
+    from cecli.tui.widgets import StatusBar
+
+    tui_instance.show_error("A test error", agent_name="test_agent")
+
+    # Assert query_one was called correctly
+    tui_instance.query_one.assert_called_once_with("#status-bar", StatusBar)
+
+    # Assert show_notification was called on the result of query_one
+    mock_status_bar.show_notification.assert_called_once_with(
+        "A test error",
+        severity="error",
+        timeout=5,
+        agent_name="test_agent",
     )

--- a/tests/tui/test_app.py
+++ b/tests/tui/test_app.py
@@ -220,12 +220,51 @@ def test_handle_output_message_error_with_agent_name(tui_instance, monkeypatch):
     tui_instance.worker = MagicMock()
     tui_instance.worker.coder = mock_coder
 
+
     # Mock AgentService - unknown UUID should return None (no prefix)
     monkeypatch.setattr(
         "cecli.helpers.agents.service.AgentService.get_instance",
         lambda *args: MagicMock(sub_agents={}, coder=mock_coder),
     )
 
+
+    # Test: error message for unknown agent should have agent_name=None
+    msg = {
+        "type": "error",
+        "message": "Something went wrong!",
+        "coder_uuid": "unknown_uuid",
+    }
+    tui_instance.handle_output_message(msg)
+    mock_status_bar.show_notification.assert_called_once_with(
+        "Something went wrong!",
+        severity="error",
+        timeout=5,
+        agent_name=None,
+    )
+
+
+def test_show_error_uses_query_one(tui_instance):
+    """
+    Test that show_error uses query_one to get the status bar and show a notification.
+    """
+    mock_status_bar = MagicMock()
+    tui_instance.query_one = MagicMock(return_value=mock_status_bar)
+
+    # Import StatusBar for the assertion
+    from cecli.tui.widgets import StatusBar
+
+    tui_instance.show_error("A test error", agent_name="test_agent")
+
+    # Assert query_one was called correctly
+    tui_instance.query_one.assert_called_once_with("#status-bar", StatusBar)
+
+    # Assert show_notification was called on the result of query_one
+    mock_status_bar.show_notification.assert_called_once_with(
+        "A test error",
+        severity="error",
+        timeout=5,
+        agent_name="test_agent",
+    )
     # Test: error message for unknown agent should have agent_name=None
     msg = {
         "type": "error",


### PR DESCRIPTION
This PR fixes an `AttributeError` in `TUI.show_error`. 

The `show_error` method was attempting to access `self.status_bar`, which was not an instance attribute of the `TUI` class. The fix involves using `self.query_one("#status-bar", StatusBar)` to correctly retrieve the status bar widget, following the existing pattern in the class.

Additionally, automated tests have been added in `tests/tui/test_app.py` to verify the fix and prevent regressions.

Closes CLI-43.