### PR TITLE
fix(tools): steer ReadRange away from empty-file read loops

### DIFF
--- a/cecli/tools/read_range.py
+++ b/cecli/tools/read_range.py
@@ -194,11 +194,20 @@ class Tool(BaseTool):
                 num_lines = len(lines)
 
                 if num_lines == 0:
-                    # Handle empty file case
-                    output_lines = [f"File {rel_path} is empty."]
-                    if show_index > 0:
-                        all_outputs.append("")
-                    all_outputs.extend(output_lines)
+                    new_context_details.append(
+                        "\n".join(
+                            [
+                                f"File {rel_path} is empty.",
+                                (
+                                    "Next: use EditText with start_line @000 and end_line @000 to"
+                                    " write content, or ContextManager to scaffold — do not call"
+                                    " ReadRange again on this empty file."
+                                ),
+                            ]
+                        )
+                    )
+                    new_context_retrieved.append(rel_path)
+                    cls._last_read_turn[abs_path] = coder.turn_count
                     continue
                 # 4. Determine line range
                 start_line_idx = -1

--- a/tests/tools/test_get_lines.py
+++ b/tests/tools/test_get_lines.py
@@ -142,3 +142,31 @@ def test_multiline_pattern_search(coder_with_file):
 
     assert "Retrieved context for 1 operation(s)" in result
     coder.io.tool_error.assert_not_called()
+
+
+def test_empty_file_includes_edit_hint(tmp_path):
+    empty = tmp_path / "pubspec.yaml"
+    empty.write_text("")
+    coder = DummyCoder(tmp_path)
+
+    from unittest.mock import patch
+
+    with patch("cecli.helpers.conversation.ConversationService") as conv:
+        conv.get_files.return_value.clear_ranges = Mock()
+        conv.get_files.return_value.push_range = Mock()
+        conv.get_chunks.return_value.add_file_context_messages = Mock()
+        result = read_range.Tool.execute(
+            coder,
+            show=[
+                {
+                    "file_path": "pubspec.yaml",
+                    "start_text": "@000",
+                    "end_text": "@000",
+                }
+            ],
+        )
+
+    assert "pubspec.yaml is empty" in result
+    assert "EditText" in result
+    assert "readrange again" in result.lower()
+    coder.io.tool_error.assert_not_called()


### PR DESCRIPTION
## Summary
- When ReadRange hits an empty file, return an explicit next-step hint (EditText `@000` or ContextManager) instead of a silent no-op.
- Route the message through `new_context_details` so it appears in tool output (previously written to `all_outputs`, which was never returned).

## Base branch
**Targets `v0.100.5`** (includes #557 validation pipeline) — not `main`. Merge after #557 lands, or stack into v0.100.5 before release.

## Motivation
Local models on greenfield repos loop ReadRange on empty `pubspec.yaml` / `STEERING.md` until repetition detection fires. BrightVision spec-focus implement sessions hit this in production dogfood.

## Test plan
- [x] `python -m pytest cecli/tests/tools/test_get_lines.py -q`