### PR TITLE
fix(commands): transfer abs_fnames back after /agent temp-coder turn

### DIFF
--- a/cecli/commands/utils/base_command.py
+++ b/cecli/commands/utils/base_command.py
@@ -159,6 +159,12 @@ class BaseCommand(ABC, metaclass=CommandMeta):
         await new_coder.generate(user_message=user_msg, preproc=False)
         coder.coder_commit_hashes = new_coder.coder_commit_hashes
 
+        # Transfer files added during the /agent (or other temp-coder) turn back to the original
+        if new_coder.abs_fnames - original_coder.abs_fnames:
+            original_coder.abs_fnames.update(new_coder.abs_fnames)
+        if new_coder.abs_read_only_fnames - original_coder.abs_read_only_fnames:
+            original_coder.abs_read_only_fnames.update(new_coder.abs_read_only_fnames)
+
         # Clear manager and restore original state
         ConversationService.get_manager(original_coder).initialize(
             reset=True,


### PR DESCRIPTION
## Summary

`_generic_chat_command` creates a temporary coder for `/agent` (and other slash commands with args). Files added by ContextManager during the turn were on the temp coder and got discarded when `SwitchCoderSignal` switched back to the original.

Now transfers `abs_fnames` and `abs_read_only_fnames` from the temp coder back to the original before raising `SwitchCoderSignal`. This ensures files added during `/agent` turns persist in the session and are visible to subsequent `GET /sessions/{id}` (`files_in_chat`).

## Test plan
- [x] `python -m pytest tests/ -x -q` (414 passed)
- [x] Verified via BrightVision session debug export: `files_in_chat` now reflects ContextManager-added files after /agent turn completes