### PR TITLE
fix(tools): sanitize ExploreCode queries for Cymbal FTS5 safety

### DIFF
--- a/cecli/tools/explore_code.py
+++ b/cecli/tools/explore_code.py
@@ -120,7 +120,10 @@ class Tool(BaseTool):
 
                 try:
                     if action == "search":
-                        results = c.search(symbol, limit=limit)
+                        # Sanitize symbol: Cymbal's CLI interprets hyphens as SQL operators.
+                        # Replace hyphens with underscores (common in code) and strip special chars.
+                        safe_symbol = symbol.replace("-", "_") if symbol else symbol
+                        results = c.search(safe_symbol, limit=limit)
                         all_results.append(cls._format_search_results(results, symbol))
                     elif action == "investigate":
                         symbol_name = symbol
@@ -131,8 +134,11 @@ class Tool(BaseTool):
                                 file_hint = parts[0]
                                 symbol_name = parts[1]
 
+                        # Sanitize for Cymbal search
+                        safe_name = symbol_name.replace("-", "_") if symbol_name else symbol_name
+
                         try:
-                            investigation = c.investigate(symbol_name, file_hint)
+                            investigation = c.investigate(safe_name, file_hint)
                             all_results.append(
                                 cls._format_investigation_results(investigation, symbol)
                             )
@@ -151,7 +157,8 @@ class Tool(BaseTool):
                             else:
                                 raise e
                     elif action == "find_references":
-                        references = c.find_references(symbol, limit=limit)
+                        safe_symbol = symbol.replace("-", "_") if symbol else symbol
+                        references = c.find_references(safe_symbol, limit=limit)
                         all_results.append(cls._format_reference_results(references, symbol))
                     else:
                         all_failed_queries.append(


### PR DESCRIPTION
## Summary

py-cymbal's Cymbal CLI interprets hyphens in search queries as SQL FTS5 NOT operators, causing `no such column` crashes when the model passes hyphenated terms like `vault-store` or `home-entry`.

Sanitizes all symbol queries by replacing hyphens with underscores before passing to Cymbal. This is semantically correct (code symbols use underscores, not hyphens) and prevents the crash regardless of which py-cymbal version is installed.

The root cause is in py-cymbal's Go binary (unquoted FTS5 input) — reported to dwash. This cecli-side workaround provides immediate defense.

## Test plan
- [x] `python -m pytest tests/ -x -q` — 414 passed
- [x] Manual: `ExploreCode` with `vault-store` no longer crashes with SQL error