### PR TITLE
fix(coders): initialize reflected_message in __init__ to prevent AttributeError

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -422,6 +422,7 @@ class Coder(metaclass=UsageMeta):
         self.registered_servers = {"included": set(), "excluded": set()}
         self.interrupt_event = asyncio.Event()
         self.uuid = str(generate_unique_id())
+        self.reflected_message = None
 
         if uuid:
             self.uuid = str(uuid)


### PR DESCRIPTION
## Summary

`reflected_message` was only initialized in `init_before_message()`, called from the normal `run()` loop. Code paths that bypass `run()` — such as `run_one_shot()` or `run_message()` — could trigger `check_for_file_mentions()` before `init_before_message()` was called, raising:

```
AttributeError: 'EditBlockCoder' object has no attribute 'reflected_message'
```

This occurred when a local model emitted a `[ContextManager]` file reference during a headless session (spec generation), causing `check_for_file_mentions` to access `self.reflected_message` at line 2541 of `base_coder.py`.

## Fix

Initialize `self.reflected_message = None` in `Coder.__init__()` so the attribute always exists regardless of entry point.

## Test plan

- [x] All existing pytest pass (no behavioral change — `init_before_message` still resets to None on every normal `run()`)
- [x] Reproducer: spec-gen explore turn with qwen3.6:35b emitting `[ContextManager]` no longer crashes