### PR TITLE
fix: malformed OpenRouter Anthropic model names in model-settings.yml

### DIFF
--- a/cecli/resources/model-settings.yml
+++ b/cecli/resources/model-settings.yml
@@ -2115,26 +2115,26 @@
 
 - name: openrouter/anthropic/claude-opus-4.6
   edit_format: diff
-  weak_model_name: openrouter/anthropic/claude-haiku-4-5
+  weak_model_name: openrouter/anthropic/claude-haiku-4.5
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:
     max_tokens: 128000
   cache_control: true
-  editor_model_name: openrouter/anthropic/claude-sonnet-4-5
+  editor_model_name: openrouter/anthropic/claude-sonnet-4.5
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]
   overeager: true
 
 - name: openrouter/anthropic/claude-opus-4.7
   edit_format: diff
-  weak_model_name: openrouter/anthropic/claude-haiku-4-5
+  weak_model_name: openrouter/anthropic/claude-haiku-4.5
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:
     max_tokens: 128000
   cache_control: true
-  editor_model_name: openrouter/anthropic/claude-sonnet-4-5
+  editor_model_name: openrouter/anthropic/claude-sonnet-4.5
   editor_edit_format: editor-diff
   use_temperature: false
   overeager: true
@@ -2142,20 +2142,20 @@
 
 - name: openrouter/anthropic/claude-sonnet-4.5
   edit_format: diff
-  weak_model_name: openrouter/anthropic/claude-haiku-4-5
+  weak_model_name: openrouter/anthropic/claude-haiku-4.5
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:
     max_tokens: 64000
   cache_control: true
-  editor_model_name: openrouter/anthropic/claude-sonnet-4-5
+  editor_model_name: openrouter/anthropic/claude-sonnet-4.5
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]
 
 
 - name: openrouter/anthropic/claude-haiku-4.5
   edit_format: diff
-  weak_model_name: openrouter/anthropic/claude-haiku-4-5
+  weak_model_name: openrouter/anthropic/claude-haiku-4.5
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:


### PR DESCRIPTION
These were using dashes instead of dots for the model minor version in `weak_model_name` and `editor_model_name`, which causes warnings to appear on startup.
