### PR TITLE
cli-48: Remove auto compaction for /drop, /ls, /save-session and /tokens commands

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -1733,7 +1733,7 @@ class Coder(metaclass=UsageMeta):
                 # Compacting is wasteful since /clear will clear everything
                 # and /exit will exit the application
                 stripped = user_message.strip()
-                if stripped not in ("/clear", "/reset", "/exit", "/quit"):
+                if stripped not in ("/clear", "/drop", "/exit", "/ls", "/reset", "/save-session", "/tokens", "/quit"):
                     self.compact_context_completed = False
                     await self.compact_context_if_needed()
                     self.compact_context_completed = True


### PR DESCRIPTION
This PR addresses Jira issue CLI-48 by removing automatic context compaction for the following commands:
- `/drop`
- `/ls`
- `/save-session`
- `/tokens`

These commands are necessary to determine the current state of the conversation and compaction steps, so automatic compaction during their execution could interfere with their intended functionality.

**Changes:**
- Modified command execution logic to skip automatic compaction for the specified commands.

**Jira Issue:** [CLI-48](https://jira.example.com/browse/CLI-48) (Note: Replace with actual Jira URL if available)