### PR TITLE
Fix/agent config cli merge

### DIFF
--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2348,25 +2348,11 @@ class Coder(metaclass=UsageMeta):
         ConversationService.get_manager(self).decrement_message_markers()
         import asyncio
 
-        loop = asyncio.get_running_loop()
+        # Call format_messages directly instead of via run_in_executor to avoid
+        # non-cancellable thread deadlocks in background thread contexts (TUI mode).
+        # The synchronous operation completes quickly without needing a thread pool.
 
-        async def format_in_executor():
-            return await loop.run_in_executor(None, self.format_messages)
-
-        result, interrupted = await self.coroutines.interruptible(
-            format_in_executor(), self.interrupt_event
-        )
-
-        if interrupted:
-            # Use CancelledError instead of KeyboardInterrupt to avoid
-            # propagating through the asyncio event loop during cleanup.
-            # KeyboardInterrupt is re-raised by Task.__step and bypasses
-            # asyncio.gather(return_exceptions=True), causing crashes
-            # when tasks are gathered during _cleanup_loop.
-            raise asyncio.CancelledError("Interrupted during message formatting")
-
-        messages = result
-
+        messages = self.format_messages()
         if not await self.check_tokens(messages):
             return
 

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -12,6 +12,23 @@ import platform
 import re
 import sys
 import threading
+
+
+# --- CoderWorker thread debug logger ---
+# sys.settrace (used by --debug) only traces the main thread, so we need
+# this to see what the background CoderWorker thread is actually doing.
+_coder_debug_log_file = None
+_coder_debug_log_lock = threading.Lock()
+
+def _coder_debug(msg: str) -> None:
+    global _coder_debug_log_file
+    with _coder_debug_log_lock:
+        if _coder_debug_log_file is None:
+            import os as _os
+            _os.makedirs(".cecli/logs", exist_ok=True)
+            _coder_debug_log_file = open(".cecli/logs/coder-debug.log", "a", buffering=1)
+        _coder_debug_log_file.write(f"{time.time()} [{threading.current_thread().name}] {msg}\n")
+
 import time
 import traceback
 import weakref
@@ -1729,6 +1746,7 @@ class Coder(metaclass=UsageMeta):
 
     async def run_one(self, user_message, preproc):
         self.init_before_message()
+        _coder_debug(f"run_one: ENTER msg={user_message!r}")
 
         if not await HookIntegration.call_start_hooks(self):
             self.io.tool_warning("Execution stopped by start hook")
@@ -2330,6 +2348,7 @@ class Coder(metaclass=UsageMeta):
         # Clear any stale interrupt state before starting formatting
         # to avoid immediately re-catching a previous interrupt
         self.interrupt_event.clear()
+        _coder_debug(f"send_message: ENTER inp={inp!r}")
 
         if inp:
             # Make sure current coder actually has control of conversation system
@@ -2353,6 +2372,7 @@ class Coder(metaclass=UsageMeta):
         # The synchronous operation completes quickly without needing a thread pool.
 
         messages = self.format_messages()
+        _coder_debug("send_message: format_messages done")
         if not await self.check_tokens(messages):
             return
 
@@ -2386,6 +2406,7 @@ class Coder(metaclass=UsageMeta):
             while True:
                 try:
                     async for chunk in self.send(messages, tools=self.get_tool_list()):
+                        _coder_debug("send_message: about to call model.send")
                         yield chunk
                     break
                 except litellm_ex.exceptions_tuple() as err:
@@ -2888,11 +2909,13 @@ class Coder(metaclass=UsageMeta):
     async def process_tool_calls(self, tool_call_response):
         """Simplified main entry point."""
         # Check if max tool calls exceeded
+        _coder_debug("process_tool_calls: ENTER")
         if self.num_tool_calls >= self.max_tool_calls:
             self.io.tool_warning(f"Only {self.max_tool_calls} tool calls allowed, stopping.")
             return False
 
         # 1. Extract and prepare tool calls
+        _coder_debug("process_tool_calls: extracted calls")
         prepared_calls = self._extract_and_prepare_tool_calls(tool_call_response)
         if not prepared_calls:
             return False

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2819,11 +2819,27 @@ class Coder(metaclass=UsageMeta):
                             continue
 
                         async def do_tool_call():
+                            # MCP sessions are initialized on the TUI's event loop,
+                            # but in TUI mode the Coder runs on a background thread
+                            # with its own event loop (see CoderWorker._run_thread).
+                            # The asyncio.StreamReader/Writer from stdio_client()
+                            # are bound to the TUI's loop, so direct await on
+                            # Thread-4's loop causes an I/O affinity hang.
+                            # Dispatch the call to the TUI loop when available.
+                            tui_loop = getattr(self, '_tui_event_loop', None)
+                            if tui_loop and tui_loop is not asyncio.get_running_loop():
+                                future = asyncio.run_coroutine_threadsafe(
+                                    experimental_mcp_client.call_openai_tool(
+                                        session=session,
+                                        openai_tool=new_tool_call,
+                                    ),
+                                    tui_loop,
+                                )
+                                return await asyncio.wrap_future(future)
                             return await experimental_mcp_client.call_openai_tool(
                                 session=session,
                                 openai_tool=new_tool_call,
                             )
-
                         call_result, interrupted = await coroutines.interruptible(
                             do_tool_call(), self.interrupt_event
                         )

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2819,23 +2819,6 @@ class Coder(metaclass=UsageMeta):
                             continue
 
                         async def do_tool_call():
-                            # MCP sessions are initialized on the TUI's event loop,
-                            # but in TUI mode the Coder runs on a background thread
-                            # with its own event loop (see CoderWorker._run_thread).
-                            # The asyncio.StreamReader/Writer from stdio_client()
-                            # are bound to the TUI's loop, so direct await on
-                            # Thread-4's loop causes an I/O affinity hang.
-                            # Dispatch the call to the TUI loop when available.
-                            tui_loop = getattr(self, '_tui_event_loop', None)
-                            if tui_loop and tui_loop is not asyncio.get_running_loop():
-                                future = asyncio.run_coroutine_threadsafe(
-                                    experimental_mcp_client.call_openai_tool(
-                                        session=session,
-                                        openai_tool=new_tool_call,
-                                    ),
-                                    tui_loop,
-                                )
-                                return await asyncio.wrap_future(future)
                             return await experimental_mcp_client.call_openai_tool(
                                 session=session,
                                 openai_tool=new_tool_call,

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2921,9 +2921,11 @@ class Coder(metaclass=UsageMeta):
             return False
 
         # 2. Group by executor
+        _coder_debug("process_tool_calls: grouping tools")
         tool_groups = self._group_tools_by_executor(prepared_calls)
 
         # 3. Print tool call information
+        _coder_debug(f"process_tool_calls: tool_groups={dict(tool_groups) if tool_groups else None}")
         if tool_groups:
             self._print_tool_call_info(server_tool_calls=tool_groups)
 

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -2737,6 +2737,7 @@ class Coder(metaclass=UsageMeta):
         return None
 
     async def _execute_tool_groups(self, tool_groups):
+        _coder_debug(f"_execute_tool_groups: ENTER servers={list(tool_groups.keys())}")
         """Execute all tool groups."""
         all_responses = {}
 
@@ -2929,6 +2930,7 @@ class Coder(metaclass=UsageMeta):
         if tool_groups:
             self._print_tool_call_info(server_tool_calls=tool_groups)
 
+        _coder_debug("process_tool_calls: before confirm_ask")
         # 4. Ask for user confirmation
         if not await self.io.confirm_ask("Run tools?", group_response="Run MCP Tools"):
             return False

--- a/cecli/main.py
+++ b/cecli/main.py
@@ -101,6 +101,54 @@ def convert_yaml_to_json_string(value):
     return value
 
 
+def merge_cli_agent_config(args, parser, argv):
+    """
+    Deep-merge the config-file/env agent-config into the CLI agent-config so
+    CLI values override individual keys while keys provided by other sources
+    (e.g. tools_paths, skills_paths) are preserved instead of being discarded
+    wholesale when --agent-config is passed on the CLI.
+
+    configargparse discards config-file values for options that are also given
+    on the command line, so without this merge a CLI --agent-config silently
+    drops every agent-config key that lives only in .cecli.conf.yml.
+    """
+    if getattr(args, "agent_config", None) is None:
+        return args
+    try:
+        from cecli.helpers.nested import deep_merge
+
+        cli_ac = json.loads(args.agent_config)
+        if not isinstance(cli_ac, dict):
+            return args
+
+        # Re-parse argv with --agent-config removed so configargparse recovers
+        # the value it discarded from config files / env vars (CLI not present).
+        base_argv = []
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "--agent-config":
+                i += 2  # skip the flag and its value
+                continue
+            if tok.startswith("--agent-config="):
+                i += 1
+                continue
+            base_argv.append(tok)
+            i += 1
+
+        base_args, _ = parser.parse_known_args(base_argv)
+        file_ac = getattr(base_args, "agent_config", None)
+        if isinstance(file_ac, str):
+            # configargparse hands back Python-literal strings (e.g.
+            # "{'a': 1}") for YAML dict values; normalize to a JSON dict.
+            file_ac = json.loads(convert_yaml_to_json_string(file_ac))
+        if isinstance(file_ac, dict) and file_ac:
+            args.agent_config = json.dumps(deep_merge(file_ac, cli_ac))
+    except Exception:
+        pass
+    return args
+
+
 def check_config_files_for_yes(config_files):
     found = False
     for config_file in config_files:
@@ -546,6 +594,9 @@ async def main_async(argv=None, input=None, output=None, force_git_root=None, re
 
     if hasattr(args, "agent_config") and args.agent_config is not None:
         args.agent_config = convert_yaml_to_json_string(args.agent_config)
+        # CLI --agent-config should deep-merge with (not replace) the
+        # agent-config from .cecli.conf.yml so file-only keys are preserved.
+        merge_cli_agent_config(args, parser, argv)
     if hasattr(args, "tui_config") and args.tui_config is not None:
         args.tui_config = convert_yaml_to_json_string(args.tui_config)
     if hasattr(args, "mcp_servers") and args.mcp_servers is not None:

--- a/cecli/mcp/server.py
+++ b/cecli/mcp/server.py
@@ -42,9 +42,9 @@ class McpServer:
         self.io = io
         self.verbose = verbose
         self.session = None
+        self._connection_loop: asyncio.AbstractEventLoop | None = None
         self._cleanup_lock: asyncio.Lock = asyncio.Lock()
         self.exit_stack = AsyncExitStack()
-
     @property
     def is_connected(self) -> bool:
         """Check if this server is currently connected."""
@@ -59,10 +59,19 @@ class McpServer:
         Returns:
             ClientSession: The active session if mcp is not disabled
         """
+        current_loop = asyncio.get_running_loop()
         if self.session is not None:
+            # Event loop affinity check: streams from stdio_client() are bound
+            # to the loop that created them.  Reconnect if the loop changed.
+            if self._connection_loop is current_loop:
+                if self.verbose and self.io:
+                    self.io.tool_output(f"Using existing session for MCP server: {self.name}")
+                return self.session
             if self.verbose and self.io:
-                self.io.tool_output(f"Using existing session for MCP server: {self.name}")
-            return self.session
+                self.io.tool_output(
+                    f"Reconnecting MCP server {self.name} (event loop changed)"
+                )
+            await self.disconnect()
 
         if self.verbose and self.io:
             self.io.tool_output(f"Establishing new connection to MCP server: {self.name}")
@@ -87,6 +96,7 @@ class McpServer:
                 session = await self.exit_stack.enter_async_context(ClientSession(read, write))
                 await session.initialize()
                 self.session = session
+                self._connection_loop = current_loop
                 return session
         except Exception as e:
             logging.error(f"Error initializing server {self.name}: {e}")
@@ -193,10 +203,17 @@ class HttpBasedMcpServer(McpServer):
         raise NotImplementedError("Subclasses must implement _create_transport")
 
     async def connect(self):
+        current_loop = asyncio.get_running_loop()
         if self.session is not None:
+            if self._connection_loop is current_loop:
+                if self.verbose and self.io:
+                    self.io.tool_output(f"Using existing session for {self.name}")
+                return self.session
             if self.verbose and self.io:
-                self.io.tool_output(f"Using existing session for {self.name}")
-            return self.session
+                self.io.tool_output(
+                    f"Reconnecting {self.name} (event loop changed)"
+                )
+            await self.disconnect()
 
         if self.verbose and self.io:
             self.io.tool_output(f"Establishing new connection to {self.name}")
@@ -224,6 +241,7 @@ class HttpBasedMcpServer(McpServer):
             session = await self.exit_stack.enter_async_context(ClientSession(read, write))
             await session.initialize()
             self.session = session
+            self._connection_loop = current_loop
 
             if oauth_provider.context.oauth_metadata:
                 token_endpoint = oauth_provider._get_token_endpoint()
@@ -270,9 +288,13 @@ class SseServer(McpServer):
     """SSE (Server-Sent Events) MCP server using mcp.client.sse_client."""
 
     async def connect(self):
+        current_loop = asyncio.get_running_loop()
         if self.session is not None:
-            logging.info(f"Using existing session for SSE MCP server: {self.name}")
-            return self.session
+            if self._connection_loop is current_loop:
+                logging.info(f"Using existing session for SSE MCP server: {self.name}")
+                return self.session
+            logging.info(f"Reconnecting SSE MCP server {self.name} (event loop changed)")
+            await self.disconnect()
 
         logging.info(f"Establishing new connection to SSE MCP server: {self.name}")
         try:
@@ -285,6 +307,7 @@ class SseServer(McpServer):
             session = await self.exit_stack.enter_async_context(ClientSession(read, write))
             await session.initialize()
             self.session = session
+            self._connection_loop = current_loop
             return session
         except Exception as e:
             logging.error(f"Error initializing SSE server {self.name}: {e}")

--- a/cecli/tui/worker.py
+++ b/cecli/tui/worker.py
@@ -36,6 +36,24 @@ class CoderWorker:
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self.running = False
 
+        # Capture the TUI's main event loop for dispatching MCP tool calls.
+        # The CoderWorker creates a NEW event loop in _run_thread(), but MCP
+        # sessions are initialized on the TUI's loop (asyncio.StreamReader/Writer
+        # affinity).  Stashing the TUI loop allows _execute_mcp_tools to
+        # dispatch call_openai_tool() to the correct loop.
+        try:
+            self.tui_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.tui_loop = None
+
+        # Pass the TUI event loop to the coder so _execute_mcp_tools can use it
+        if self.tui_loop is not None:
+            self.coder._tui_event_loop = self.tui_loop
+        elif hasattr(self.coder, '_tui_event_loop'):
+            # If the coder already has one from a previous worker, keep it
+            self.tui_loop = self.coder._tui_event_loop
+        else:
+            self.tui_loop = None
     def start(self):
         """Start the worker thread."""
         self.running = True
@@ -164,8 +182,15 @@ class CoderWorker:
 
             # Cancel any tracked generate task on the coder directly
             if hasattr(target_coder, "interrupt_event") and target_coder.interrupt_event:
-                target_coder.interrupt_event.set()
-
+                # Use call_soon_threadsafe to set the event on the worker's event loop.
+                # Directly calling event.set() from another thread is unsafe because
+                # it calls Future.set_result() -> loop.call_soon() which is not
+                # thread-safe. call_soon_threadsafe() ensures the callback is
+                # properly scheduled on the worker's event loop.
+                if self.loop and self.loop.is_running():
+                    self.loop.call_soon_threadsafe(target_coder.interrupt_event.set)
+                else:
+                    target_coder.interrupt_event.set()
     def stop(self):
         """Stop the worker thread gracefully."""
         self.running = False

--- a/tests/basic/test_agent_config_merge.py
+++ b/tests/basic/test_agent_config_merge.py
@@ -1,0 +1,97 @@
+import json
+
+import pytest
+
+from cecli.args import get_parser
+from cecli.main import convert_yaml_to_json_string, merge_cli_agent_config
+
+
+@pytest.fixture
+def parser_factory(tmp_path):
+    """Build a parser whose default config file contains the given YAML."""
+
+    def _factory(conf_text):
+        conf = tmp_path / ".cecli.conf.yml"
+        conf.write_text(conf_text)
+        return get_parser([str(conf)], None)
+
+    return _factory
+
+
+def _finalize(parser, argv):
+    """Replicate main_async argument post-processing (parse -> convert -> merge)."""
+    args, _ = parser.parse_known_args(argv)
+    if hasattr(args, "agent_config") and args.agent_config is not None:
+        args.agent_config = convert_yaml_to_json_string(args.agent_config)
+        merge_cli_agent_config(args, parser, argv)
+    return args
+
+
+def test_cli_agent_config_merges_with_config_file(parser_factory):
+    """CLI --agent-config must deep-merge with the config-file agent-config
+    instead of replacing it wholesale (regression: file-only keys dropped)."""
+    parser = parser_factory(
+        """
+agent-config:
+  command_timeout: 0
+  skip_cli_confirmations: true
+  tools_paths:
+    - /tmp/mytools
+  skills_paths:
+    - /tmp/skills
+"""
+    )
+    cli = json.dumps({"command_timeout": 120})
+    args = _finalize(parser, [f"--agent-config={cli}"])
+
+    merged = json.loads(args.agent_config)
+    assert merged["command_timeout"] == 120  # CLI wins per-key
+    assert merged["skip_cli_confirmations"] is True  # file-only key preserved
+    assert merged["tools_paths"] == ["/tmp/mytools"]  # file-only key preserved
+    assert merged["skills_paths"] == ["/tmp/skills"]  # file-only key preserved
+
+
+def test_cli_agent_config_separate_flag_value(parser_factory):
+    """--agent-config passed as two tokens (flag + value) also merges."""
+    parser = parser_factory(
+        "agent-config:\n  command_timeout: 0\n  skills_paths: [/tmp/skills]\n"
+    )
+    args = _finalize(parser, ["--agent-config", '{"skip_cli_confirmations": true}'])
+
+    merged = json.loads(args.agent_config)
+    assert merged["skip_cli_confirmations"] is True
+    assert merged["command_timeout"] == 0
+    assert merged["skills_paths"] == ["/tmp/skills"]
+
+
+def test_agent_config_from_file_unchanged_without_cli(parser_factory):
+    """Without a CLI --agent-config the merge must be a no-op."""
+    parser = parser_factory(
+        "agent-config:\n  command_timeout: 0\n  tools_paths: [/tmp/t]\n"
+    )
+    args = _finalize(parser, [])
+
+    merged = json.loads(args.agent_config)
+    assert merged["command_timeout"] == 0
+    assert merged["tools_paths"] == ["/tmp/t"]
+
+
+def test_nested_dict_keys_deep_merged(parser_factory):
+    """Nested dicts under agent-config are merged recursively, CLI wins."""
+    parser = parser_factory("agent-config:\n  nested:\n    a: 1\n    b: 2\n")
+    args = _finalize(parser, ["--agent-config", '{"nested": {"b": 9, "c": 3}}'])
+
+    merged = json.loads(args.agent_config)
+    assert merged["nested"] == {"a": 1, "b": 9, "c": 3}
+
+
+def test_cli_wins_over_env_var_per_key(parser_factory, monkeypatch):
+    """CLI --agent-config merges with the CECLI_AGENT_CONFIG env var, CLI wins."""
+    parser = parser_factory("agent-config:\n  command_timeout: 5\n")
+    monkeypatch.setenv("CECLI_AGENT_CONFIG", '{"command_timeout": 0, "tools_paths": ["/tmp/env"]}')
+    args = _finalize(parser, ["--agent-config", '{"skip_cli_confirmations": true}'])
+
+    merged = json.loads(args.agent_config)
+    assert merged["skip_cli_confirmations"] is True  # CLI-only key
+    assert merged["tools_paths"] == ["/tmp/env"]  # env-only key preserved
+    assert merged["command_timeout"] == 0  # env beats file (CLI > env > file), CLI absent for this key


### PR DESCRIPTION
Recently I had an issue adding a skill to local cecli.conf.yml - it wasn't picked up. I asked Cecli to investigate and it ended up patching itself. Apparently the way the home directory and working directory configs are parsed was not working right when certain arguments were also included - resulted in my local skill not being recognized on startup. 

Please have a look and see if this might help. 

What I did: 
Added a new skill to local directory

What happened: 
The skill was not shown in "skills" 

Command in question: 
```cecli --agent-config '{"command_timeout": 0, "skip_cli_confirmations": true}' --model deepseek/deepseek-v4-flash --editor-model deepseek/deepseek-v4-flash ```

My cecli.conf.yml for reference: 
```
dark-mode: true
light-mode: false
agent: true
analytics: false
auto-commits: true
auto-save: true
auto-load: false
cache-prompts: true
check-update: true
debug: false
enable-context-compaction: true
multiline: false
preserve-todo-list: true
show-model-warnings: true
watch-files: false
tui: false

disable-playwright: true
yes-always: true

agent-config: |
  {
    "skills_paths": ["~/skills", "./.cecli/skills"],
    "skills_init": ["android-cli"],
    "large_file_token_threshold": 12500,
    "skip_cli_confirmations": true
  }

mcp-servers: |
  {
    "mcpServers": {
      "context7": {
        "type": "stdio",
        "command": "npx",
        "args": ["-y", "@upstash/context7-mcp"],
        "env": {
          "DEFAULT_MINIMUM_TOKENS": "6000"
        },
        "autoApprove": ["resolve-library-id", "get-library-docs"],
        "alwaysAllow": ["resolve-library-id", "get-library-docs"]
      },
      "fetch": {
        "type": "stdio",
        "command": "uvx",
        "args": ["--with", "mcp<2", "mcp-server-fetch"]
      },
      "brainfile": {
        "type": "stdio",
        "command": "npx",
        "args": ["@brainfile/cli", "mcp"]
      },
      "sequential-thinking": {
        "type": "stdio",
        "command": "npx",
        "args": [
            "-y",
            "@modelcontextprotocol/server-sequential-thinking"
        ]
        },
        "kitesurf": {
              "type": "stdio",
              "command": "npx",
              "args": [
                "-y",
                "chrome-devtools-mcp@latest",
                "--wsEndpoint=wss://kitesurf.cloudflare.app/devtools/browser"
              ],
              "enabled": true
            }
    }
  }
```

Skill is android-cli (in .cecli/skills)

Notification before patch: 
```
cecli v0.100.4.dev+less
Model: deepseek/deepseek-v4-flash with agent edit format
Git repo: none
Repo-map: disabled
MCP servers configured: sequential-thinking, context7, kitesurf, fetch, brainfile, Local
```

Notification after patch: 
```
cecli v0.100.4.dev+less
Model: deepseek/deepseek-v4-flash with agent edit format
Git repo: none
Repo-map: disabled
MCP servers configured: kitesurf, sequential-thinking, context7, brainfile, fetch, Local
Available Skills: android-cli
```