### PR TITLE
make it possible for sub-agents to use MCP servers

### DIFF
--- a/cecli/coders/agent_coder.py
+++ b/cecli/coders/agent_coder.py
@@ -1627,9 +1627,9 @@ Todo list does not exist. Please update it with the `UpdateTodoList` tool.</cont
             inactive_servers = []
             for server in connected_servers:
                 name = server.name
-                if incl and name not in incl:
+                if incl and name.lower() not in incl:
                     inactive_servers.append(name)
-                elif name in excl:
+                elif name.lower() in excl:
                     inactive_servers.append(name)
                 else:
                     active_servers.append(name)

--- a/cecli/coders/base_coder.py
+++ b/cecli/coders/base_coder.py
@@ -939,10 +939,10 @@ class Coder(metaclass=UsageMeta):
             for server_name, server_tools in self.mcp_tools:
                 if (
                     self.registered_servers["included"]
-                    and server_name not in self.registered_servers["included"]
+                    and server_name.lower() not in self.registered_servers["included"]
                 ):
                     continue
-                if server_name in self.registered_servers["excluded"]:
+                if server_name.lower() in self.registered_servers["excluded"]:
                     continue
                 mcp_servers.append(server_name)
             if mcp_servers:
@@ -3356,10 +3356,10 @@ class Coder(metaclass=UsageMeta):
                 # Apply per-instance server filtering
                 if (
                     self.registered_servers["included"]
-                    and server_name not in self.registered_servers["included"]
+                    and server_name.lower() not in self.registered_servers["included"]
                 ):
                     continue
-                if server_name in self.registered_servers["excluded"]:
+                if server_name.lower() in self.registered_servers["excluded"]:
                     continue
 
                 for tool in server_tools:

--- a/cecli/helpers/agents/service.py
+++ b/cecli/helpers/agents/service.py
@@ -565,11 +565,19 @@ class AgentService:
         )
 
         if agent_config:
+            # Reset the per-instance tool/server filters so AgentCoder.post_init()
+            # rebuilds them from *this* sub-agent's own agent-config (tools_includelist/
+            # excludelist, servers_includelist/excludelist) instead of inheriting the
+            # parent's filters verbatim. Deliberately do NOT reset mcp_manager here:
+            # doing so used to discard the parent's already-connected MCP servers and
+            # replace them with a brand new, empty manager, making it impossible for a
+            # sub-agent's servers_includelist to ever match anything. Leaving mcp_manager
+            # unset lets it inherit from from_coder (see Coder.create()) so the same
+            # connected MCP servers remain available and can then be filtered.
             kwargs.update(
                 dict(
                     registered_tools=None,
                     registered_servers=None,
-                    mcp_manager=None,
                 )
             )
 


### PR DESCRIPTION
My sub-agents could not connect to MCP servers without this change. The meat of it is a one-liner in `cecli/helpers/agents/service.py`, maybe you @dwash96 want to take a critical look whether that makes sense or could introduce other issues (I'm not sure whether the previous logic was intentional). Please let me know if you need more context.