### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/cecli/website/docs/config/gbr.md
+++ b/cecli/website/docs/config/gbr.md
@@ -1,0 +1,61 @@
+---
+parent: Configuration
+nav_order: 125
+description: Pair a phone running Build Remote Agent to a cecli session (gbr/1).
+---
+
+# Pair a phone with Build Remote Agent
+
+cecli can keep orchestrating in the terminal while a phone running
+**Build Remote Agent** spectates the same desktop session through the
+free MIT `gbr-agent`. Phone and PC never open ports to each other.
+
+Website: https://grokbuildremote.com/  
+Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)  
+Protocol: `gbr/1` · need agent **v0.6.0+**
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+## Install + pair
+
+```bash
+# macOS / Linux
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # must print v0.6.0 or newer
+gbr-agent pair             # QR in browser + printed 8-char code
+gbr-agent run              # leave running, then start cecli as usual
+```
+
+```powershell
+# Windows
+irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version
+gbr-agent pair
+gbr-agent run
+```
+
+Phone: open Build Remote Agent → **Scan QR from computer** (or type the
+8-char code). **Unpair** in Settings before changing PCs. Force-close is
+not enough.
+
+## Attach
+
+After `gbr-agent run`:
+
+- HTTP Bot API: `http://127.0.0.1:8788`
+- MCP stdio: see the `gbr` example in [MCP](mcp.md)
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Phone is spectator + veto. Orchestration stays in cecli.
+
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only
+place the relay key is copied.
+
+## Skill (optional)
+
+cecli loads skills from directories in `skills_paths`. A `gbr/SKILL.md`
+can teach agent mode the pair/run/attach loop. See [Skills](skills.md).

--- a/cecli/website/docs/config/mcp.md
+++ b/cecli/website/docs/config/mcp.md
@@ -227,6 +227,50 @@ mcp-servers:
       ]
 ```
 
+### Build Remote Agent (phone pairing)
+
+Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to this
+cecli session. Protocol `gbr/1`. Install `gbr-agent` v0.6.0+, run
+`gbr-agent pair` (QR + 8-char code) then `gbr-agent run`. The phone is
+spectator + veto — it does not replace cecli. Independent product; not
+affiliated with xAI or SpaceX.
+
+Attach only `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Never put mailbox
+keys in this file.
+
+```yaml
+mcp-servers:
+  mcpServers:
+    gbr:
+      transport: stdio
+      command: node
+      args:
+        - GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js
+```
+
+Point `args` at the absolute path of `bin/gbr-mcp.js` after:
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+```
+
+HTTP loopback is also valid:
+
+```yaml
+mcp-servers:
+  mcpServers:
+    gbr:
+      transport: http
+      url: http://127.0.0.1:8788
+      keepalive_interval: 60
+```
+
+See [Pair a phone with Build Remote Agent](gbr.md) for the full pair/run loop.
+
 ### You.com Search (Paid Service)
 
 You.com MCP provides live web and news search with LLM-ready results, useful when the model needs current information — release notes, library docs, error messages — beyond its training cutoff, and as the search complement to `/web` (search first, then scrape the best result).


### PR DESCRIPTION
Add a pairing-device adapter so a phone running **Build Remote Agent** can spectate a cecli session.

Protocol stays `gbr/1`. Pair with `gbr-agent pair` (browser QR **and** printed 8-char code) then `gbr-agent run`. Attach **only**:

- HTTP Bot API `http://127.0.0.1:8788`
- MCP stdio `gbr-mcp` (example added under Common MCP Servers)

Files:
- `cecli/website/docs/config/mcp.md` — `gbr` stdio/http snippet
- `cecli/website/docs/config/gbr.md` — install / pair / attach

The phone is spectator + veto, not orchestrator. No mailbox keys in this PR.

Note on the head branch name: GitHub allows only one fork per network, and this account already forked `Aider-AI/aider` (cecli's parent). The patch lives on `feat/gbr-pair-cecli` of that network fork, based on `cecli-dev/cecli` main — not on Aider's main.

Docs: https://grokbuildremote.com/
Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.